### PR TITLE
Implement `LakeFSFileSystem.open()` in write mode

### DIFF
--- a/tests/test_lakefs_file.py
+++ b/tests/test_lakefs_file.py
@@ -3,7 +3,7 @@ from lakefs_spec.spec import LakeFSFileSystem
 from tests.util import RandomFileFactory
 
 
-def test_lakefs_file_open(
+def test_lakefs_file_open_read(
     lakefs_client: LakeFSClient,
     repository: str,
     temp_branch: str,
@@ -23,3 +23,31 @@ def test_lakefs_file_open(
         text = fp.read()
 
     assert text == orig_text
+
+
+def test_lakefs_file_open_write(
+    lakefs_client: LakeFSClient,
+    repository: str,
+    temp_branch: str,
+    random_file_factory: RandomFileFactory,
+) -> None:
+    random_file = random_file_factory.make()
+    with open(random_file, "rb") as f:
+        orig_text = f.read()
+
+    fs = LakeFSFileSystem(client=lakefs_client)
+    rpath = f"{repository}/{temp_branch}/{random_file.name}"
+
+    # try opening the remote file and writing to it
+    with fs.open(rpath, "wb") as fp:
+        fp.write(orig_text)
+
+    # pulling the written file down again, using ONLY built-in open (!)
+    lpath = random_file.with_name(random_file.name + "_copy")
+    fs.get(rpath, str(lpath))
+
+    with open(lpath, "rb") as f:
+        new_text = f.read()
+
+    # round-trip assert.
+    assert new_text == orig_text


### PR DESCRIPTION
Since the lakeFS client does not allow multipart uploads, as a workaround, write the whole file in a single chunk. Warn about the performance indications as well.

TODO:

- [ ] Run `pre-commit` 
- [ ] Testing (unit? end-to-end with `open(..., "rb")`?)