### PR TITLE
Switch lakeFS CI instance to service container

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -16,6 +16,18 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    services:
+      lakefs:
+        image: treeverse/lakefs:0.107.0
+        ports:
+          - 8000:8000
+        env:
+          LAKEFS_INSTALLATION_USER_NAME: "quickstart"
+          LAKEFS_INSTALLATION_ACCESS_KEY_ID: "AKIAIOSFOLQUICKSTART"
+          LAKEFS_INSTALLATION_SECRET_ACCESS_KEY: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+          LAKEFS_DATABASE_TYPE: "local"
+          LAKEFS_AUTH_ENCRYPT_SECRET_KEY: "THIS_MUST_BE_CHANGED_IN_PRODUCTION"
+          LAKEFS_BLOCKSTORE_TYPE: "local"
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.11

--- a/dev-deps.lock
+++ b/dev-deps.lock
@@ -10,20 +10,12 @@ build==0.10.0
     # via lakefs-spec (pyproject.toml)
 certifi==2023.7.22
     # via requests
-cffi==1.15.1
-    # via cryptography
 cfgv==3.3.1
     # via pre-commit
 charset-normalizer==3.2.0
     # via requests
-cryptography==41.0.3
-    # via secretstorage
-deprecation==2.1.0
-    # via testcontainers
 distlib==0.3.7
     # via virtualenv
-docker==6.1.3
-    # via testcontainers
 docutils==0.20.1
     # via readme-renderer
 filelock==3.12.2
@@ -42,10 +34,6 @@ iniconfig==2.0.0
     # via pytest
 jaraco-classes==3.3.0
     # via keyring
-jeepney==0.8.0
-    # via
-    #   keyring
-    #   secretstorage
 keyring==24.2.0
     # via twine
 lakefs-client==0.107.0
@@ -61,8 +49,6 @@ nodeenv==1.8.0
 packaging==23.1
     # via
     #   build
-    #   deprecation
-    #   docker
     #   pytest
 pkginfo==1.9.6
     # via twine
@@ -72,8 +58,6 @@ pluggy==1.2.0
     # via pytest
 pre-commit==3.3.3
     # via lakefs-spec (pyproject.toml)
-pycparser==2.21
-    # via cffi
 pygments==2.16.1
     # via
     #   readme-renderer
@@ -90,7 +74,6 @@ readme-renderer==41.0
     # via twine
 requests==2.31.0
     # via
-    #   docker
     #   requests-toolbelt
     #   twine
 requests-toolbelt==1.0.0
@@ -99,19 +82,14 @@ rfc3986==2.0.0
     # via twine
 rich==13.5.2
     # via twine
-secretstorage==3.3.3
-    # via keyring
 six==1.16.0
     # via
     #   bleach
     #   python-dateutil
-testcontainers==3.7.1
-    # via lakefs-spec (pyproject.toml)
 twine==4.0.2
     # via lakefs-spec (pyproject.toml)
 urllib3==2.0.4
     # via
-    #   docker
     #   lakefs-client
     #   requests
     #   twine
@@ -119,10 +97,6 @@ virtualenv==20.24.2
     # via pre-commit
 webencodings==0.5.1
     # via bleach
-websocket-client==1.6.1
-    # via docker
-wrapt==1.15.0
-    # via testcontainers
 zipp==3.16.2
     # via importlib-metadata
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ Issues = "https://github.com/appliedai-initiative/lakefs-spec/issues"
 dev = [
     "pre-commit>=3.3.3",
     "pytest>=7.4.0",
-    "testcontainers>=3.7.1",
     "twine>=4.0.0",
     "build>=0.10.0",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,17 +2,13 @@ import logging
 import random
 import string
 import sys
-import time
 from pathlib import Path
 from typing import Generator, TypeVar
 
 import pytest
 from lakefs_client import Configuration
-from lakefs_client import __version__ as lakefs_version
 from lakefs_client.client import LakeFSClient
 from lakefs_client.models import BranchCreation, CommPrefsInput, RepositoryCreation
-from testcontainers.core.container import DockerContainer
-from testcontainers.core.waiting_utils import wait_container_is_ready
 
 from tests.util import RandomFileFactory
 
@@ -29,24 +25,17 @@ YieldFixture = Generator[T, None, None]
 
 @pytest.fixture(scope="session")
 def lakefs_client(_lakefs_client: LakeFSClient) -> YieldFixture[LakeFSClient]:
-    """A lakeFS client for a sidecar testcontainer with quickstart settings and communication preferences set."""
+    """A lakeFS client with communication preferences set."""
 
-    # Note: Quickstart is only available in lakeFS>=0.105.0
-    with DockerContainer(f"treeverse/lakefs:{lakefs_version}").with_command(
-        ["run", "--quickstart"]
-    ).with_bind_ports(8000, 8000) as container:
-        wait_container_is_ready()(container)
-        time.sleep(1)
+    # Set up comm preferences
+    comms_prefs = CommPrefsInput(
+        email="lakefs@example.org",
+        feature_updates=False,
+        security_updates=False,
+    )
+    _lakefs_client.config_api.setup_comm_prefs(comms_prefs)
 
-        # Set up comms preferences
-        comms_prefs = CommPrefsInput(
-            email="lakefs@example.org",
-            feature_updates=False,
-            security_updates=False,
-        )
-        _lakefs_client.config_api.setup_comm_prefs(comms_prefs)
-
-        yield _lakefs_client
+    yield _lakefs_client
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ from typing import Generator, TypeVar
 import pytest
 from lakefs_client import Configuration
 from lakefs_client.client import LakeFSClient
-from lakefs_client.models import BranchCreation, CommPrefsInput, RepositoryCreation
+from lakefs_client.models import BranchCreation, RepositoryCreation
 
 from tests.util import RandomFileFactory
 
@@ -24,22 +24,8 @@ YieldFixture = Generator[T, None, None]
 
 
 @pytest.fixture(scope="session")
-def lakefs_client(_lakefs_client: LakeFSClient) -> YieldFixture[LakeFSClient]:
+def lakefs_client() -> LakeFSClient:
     """A lakeFS client with communication preferences set."""
-
-    # Set up comm preferences
-    comms_prefs = CommPrefsInput(
-        email="lakefs@example.org",
-        feature_updates=False,
-        security_updates=False,
-    )
-    _lakefs_client.config_api.setup_comm_prefs(comms_prefs)
-
-    yield _lakefs_client
-
-
-@pytest.fixture(scope="session")
-def _lakefs_client() -> LakeFSClient:
     host = "localhost:8000"
     access_key_id = "AKIAIOSFOLQUICKSTART"
     secret_access_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"


### PR DESCRIPTION
https://github.com/treeverse/lakeFS/issues/6452 revealed that there is a possibility to emulate the quickstart via some environment variables.

This commit sets them and defines a GitHub Actions service container from the latest lakeFS tag to try and see if that works.