### PR TITLE
Move lakeFS file system and file to top-level module

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,5 +49,5 @@ development, add the following to your `pyproject.toml` file:
 
 ```toml
 [tool.poetry.plugins."fsspec.specs"]
-"lakefs" = "lakefs_spec.spec.LakeFSFileSystem"
+"lakefs" = "lakefs_spec.LakeFSFileSystem"
 ```

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ Its main goal is to facilitate versioned data operations in lakeFS directly from
 
 ## Installation
 
-To install the package via `pip`, run
+To install the package directly from PyPI via `pip`, run
 
 ```shell
-python3 -m pip install git+https://github.com/appliedAI-Initiative/lakefs-spec.git@v0.1.0
+python3 -m pip install lakefs-spec
 ```
 
 or, for the bleeding edge version,
@@ -18,6 +18,12 @@ python3 -m pip install git+https://github.com/appliedAI-Initiative/lakefs-spec.g
 ```
 
 To add the project as a dependency using `poetry`, use
+
+```shell
+poetry add lakefs-spec
+```
+
+or, for the development version,
 
 ```shell
 poetry add git+https://github.com/appliedAI-Initiative/lakefs-spec.git
@@ -58,7 +64,7 @@ If they match, the operations are cancelled, and no additional client-server com
 Client-side caching is enabled by default in the lakeFS file system, and can be controlled through the `precheck_files` argument in the constructor:
 
 ```python
-from lakefs_spec.spec import LakeFSFileSystem
+from lakefs_spec import LakeFSFileSystem
 
 # The default setting, precheck_files=False disables client-side caching.
 fs = LakeFSFileSystem(client, precheck_files=True)
@@ -92,7 +98,7 @@ To enable automatic commits after stateful filesystem operations, set `postcommi
 would like to use your own commit hook, supply a Python callable with the aforementioned signature as the `commithook` argument:
 
 ```python
-from lakefs_spec.spec import LakeFSFileSystem
+from lakefs_spec import LakeFSFileSystem
 
 # use the example commit hook from above
 fs = LakeFSFileSystem(client, postcommit=True, commithook=my_commit_hook)
@@ -103,7 +109,7 @@ fs = LakeFSFileSystem(client, postcommit=True, commithook=my_commit_hook)
 To selectively enable or disable automatic commits or client-side caching, you can use a `scope` context manager:
 
 ```python
-from lakefs_spec.spec import LakeFSFileSystem
+from lakefs_spec import LakeFSFileSystem
 
 fs = LakeFSFileSystem(client)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dev = [
 
 # Register lakeFS file system via the fsspec entry point
 [project.entry-points]
-"fsspec.specs" = { "lakefs" = "lakefs_spec.spec.LakeFSFileSystem" }
+"fsspec.specs" = { "lakefs" = "lakefs_spec.LakeFSFileSystem" }
 
 [tool.setuptools]
 package-dir = { "" = "src" }

--- a/src/lakefs_spec/__init__.py
+++ b/src/lakefs_spec/__init__.py
@@ -1,1 +1,3 @@
+from .spec import LakeFSFile, LakeFSFileSystem
+
 version = "0.1.1"

--- a/tests/test_checksum.py
+++ b/tests/test_checksum.py
@@ -2,7 +2,8 @@ import time
 
 from lakefs_client.client import LakeFSClient
 
-from lakefs_spec.spec import LakeFSFileSystem, md5_checksum
+from lakefs_spec import LakeFSFileSystem
+from lakefs_spec.spec import md5_checksum
 from tests.util import RandomFileFactory, with_counter
 
 

--- a/tests/test_get_file.py
+++ b/tests/test_get_file.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 from lakefs_client.client import LakeFSClient
 
-from lakefs_spec.spec import LakeFSFileSystem
+from lakefs_spec import LakeFSFileSystem
 
 
 def test_get_nonexistent_file(lakefs_client: LakeFSClient, repository: str) -> None:

--- a/tests/test_lakefs_file.py
+++ b/tests/test_lakefs_file.py
@@ -1,6 +1,6 @@
 from lakefs_client.client import LakeFSClient
 
-from lakefs_spec.spec import LakeFSFileSystem
+from lakefs_spec import LakeFSFileSystem
 from tests.util import RandomFileFactory
 
 

--- a/tests/test_ls.py
+++ b/tests/test_ls.py
@@ -1,6 +1,6 @@
 from lakefs_client.client import LakeFSClient
 
-from lakefs_spec.spec import LakeFSFileSystem
+from lakefs_spec import LakeFSFileSystem
 
 
 def test_paginated_ls(lakefs_client: LakeFSClient, repository: str) -> None:

--- a/tests/test_put_file.py
+++ b/tests/test_put_file.py
@@ -1,6 +1,6 @@
 from lakefs_client.client import LakeFSClient
 
-from lakefs_spec.spec import LakeFSFileSystem
+from lakefs_spec import LakeFSFileSystem
 from tests.util import RandomFileFactory
 
 


### PR DESCRIPTION
Adjust all example imports in the README and the registration hooks for `pyproject.toml`.