### PR TITLE
Simplify tests

### DIFF
--- a/hack/docker-compose.yml
+++ b/hack/docker-compose.yml
@@ -1,4 +1,4 @@
-# This docker-compose file provides an ephemeral lakeFS quickstart instance for local development
+# This docker-compose file provides an ephemeral lakeFS quickstart instance for local development.
 
 version: "3"
 

--- a/hack/docker-compose.yml
+++ b/hack/docker-compose.yml
@@ -1,0 +1,16 @@
+# This docker-compose file provides an ephemeral lakeFS quickstart instance for local development
+
+version: "3"
+
+services:
+  lakefs:
+    image: treeverse/lakefs:0.107.0
+    ports:
+      - 8000:8000
+    environment:
+      LAKEFS_INSTALLATION_USER_NAME: "quickstart"
+      LAKEFS_INSTALLATION_ACCESS_KEY_ID: "AKIAIOSFOLQUICKSTART"
+      LAKEFS_INSTALLATION_SECRET_ACCESS_KEY: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+      LAKEFS_DATABASE_TYPE: "local"
+      LAKEFS_AUTH_ENCRYPT_SECRET_KEY: "THIS_MUST_BE_CHANGED_IN_PRODUCTION"
+      LAKEFS_BLOCKSTORE_TYPE: "local"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import logging
 import random
 import string
 import sys
-import typing
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Generator, TypeVar
 
@@ -11,7 +11,7 @@ from lakefs_client import Configuration
 from lakefs_client.client import LakeFSClient
 from lakefs_client.models import BranchCreation, RepositoryCreation
 
-from lakefs_spec.spec import LakeFSFileSystem
+from lakefs_spec import LakeFSFileSystem
 from tests.util import RandomFileFactory
 
 _TEST_REPO = "lakefs-spec-tests"
@@ -25,7 +25,8 @@ T = TypeVar("T")
 YieldFixture = Generator[T, None, None]
 
 
-class LakeFSOptions(typing.NamedTuple):
+@dataclass
+class LakeFSOptions:
     host: str
     username: str
     password: str
@@ -43,7 +44,7 @@ def lakefs_options() -> LakeFSOptions:
 
 @pytest.fixture
 def fs(lakefs_options: LakeFSOptions) -> LakeFSFileSystem:
-    return LakeFSFileSystem(**lakefs_options._asdict())
+    return LakeFSFileSystem(**asdict(lakefs_options))
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ from lakefs_client import Configuration
 from lakefs_client.client import LakeFSClient
 from lakefs_client.models import BranchCreation, RepositoryCreation
 
+from lakefs_spec.spec import LakeFSFileSystem
 from tests.util import RandomFileFactory
 
 _TEST_REPO = "lakefs-spec-tests"
@@ -38,6 +39,11 @@ def lakefs_options() -> LakeFSOptions:
         username="AKIAIOSFOLQUICKSTART",
         password="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
     )
+
+
+@pytest.fixture
+def fs(lakefs_options: LakeFSOptions) -> LakeFSFileSystem:
+    return LakeFSFileSystem(**lakefs_options._asdict())
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_checksum.py
+++ b/tests/test_checksum.py
@@ -2,23 +2,17 @@ import time
 
 from lakefs_spec import LakeFSFileSystem
 from lakefs_spec.spec import md5_checksum
-from tests.conftest import LakeFSOptions
 from tests.util import RandomFileFactory, with_counter
 
 
 def test_checksum_matching(
     random_file_factory: RandomFileFactory,
-    lakefs_options: LakeFSOptions,
+    fs: LakeFSFileSystem,
     repository: str,
     temp_branch: str,
 ) -> None:
     random_file = random_file_factory.make()
 
-    fs = LakeFSFileSystem(
-        host=lakefs_options.host,
-        username=lakefs_options.username,
-        password=lakefs_options.password,
-    )
     fs.client, counter = with_counter(fs.client)
 
     lpath = str(random_file)

--- a/tests/test_get_file.py
+++ b/tests/test_get_file.py
@@ -3,19 +3,13 @@ from pathlib import Path
 import pytest
 
 from lakefs_spec import LakeFSFileSystem
-from tests.conftest import LakeFSOptions
 
 
-def test_get_nonexistent_file(lakefs_options: LakeFSOptions, repository: str) -> None:
+def test_get_nonexistent_file(fs: LakeFSFileSystem, repository: str) -> None:
     """
     Regression test against error on file closing in fs.get_file() after a
     lakeFS API exception.
     """
-    fs = LakeFSFileSystem(
-        host=lakefs_options.host,
-        username=lakefs_options.username,
-        password=lakefs_options.password,
-    )
     rpath = f"{repository}/main/hello-i-no-exist1234.txt"
 
     with pytest.raises(FileNotFoundError):
@@ -24,16 +18,11 @@ def test_get_nonexistent_file(lakefs_options: LakeFSOptions, repository: str) ->
     assert not Path("out.txt").exists()
 
 
-def test_get_from_nonexistent_repo(lakefs_options: LakeFSOptions) -> None:
+def test_get_from_nonexistent_repo(fs: LakeFSFileSystem) -> None:
     """
     Tests that a FileNotFoundError and not a lakeFS API exception is raised
     when attempting to access a nonexistent repository.
     """
-    fs = LakeFSFileSystem(
-        host=lakefs_options.host,
-        username=lakefs_options.username,
-        password=lakefs_options.password,
-    )
     rpath = "nonexistent-repo/main/a.txt"
 
     with pytest.raises(FileNotFoundError):
@@ -42,16 +31,11 @@ def test_get_from_nonexistent_repo(lakefs_options: LakeFSOptions) -> None:
     assert not Path("out.txt").exists()
 
 
-def test_get_from_nonexistent_branch(lakefs_options: LakeFSOptions, repository: str) -> None:
+def test_get_from_nonexistent_branch(fs: LakeFSFileSystem, repository: str) -> None:
     """
     Tests that a FileNotFoundError and not a lakeFS API exception is raised
     when attempting to access a nonexistent branch in an existing repository.
     """
-    fs = LakeFSFileSystem(
-        host=lakefs_options.host,
-        username=lakefs_options.username,
-        password=lakefs_options.password,
-    )
     rpath = f"{repository}/nonexistentbranch/a.txt"
 
     with pytest.raises(FileNotFoundError):

--- a/tests/test_lakefs_file.py
+++ b/tests/test_lakefs_file.py
@@ -1,10 +1,9 @@
 from lakefs_spec import LakeFSFileSystem
-from tests.conftest import LakeFSOptions
 from tests.util import RandomFileFactory
 
 
 def test_lakefs_file_open_read(
-    lakefs_options: LakeFSOptions,
+    fs: LakeFSFileSystem,
     repository: str,
     temp_branch: str,
     random_file_factory: RandomFileFactory,
@@ -12,12 +11,6 @@ def test_lakefs_file_open_read(
     random_file = random_file_factory.make()
     with open(random_file, "rb") as f:
         orig_text = f.read()
-
-    fs = LakeFSFileSystem(
-        host=lakefs_options.host,
-        username=lakefs_options.username,
-        password=lakefs_options.password,
-    )
 
     lpath = str(random_file)
     rpath = f"{repository}/{temp_branch}/{random_file.name}"
@@ -31,7 +24,7 @@ def test_lakefs_file_open_read(
 
 
 def test_lakefs_file_open_write(
-    lakefs_options: LakeFSOptions,
+    fs: LakeFSFileSystem,
     repository: str,
     temp_branch: str,
     random_file_factory: RandomFileFactory,
@@ -40,11 +33,6 @@ def test_lakefs_file_open_write(
     with open(random_file, "rb") as f:
         orig_text = f.read()
 
-    fs = LakeFSFileSystem(
-        host=lakefs_options.host,
-        username=lakefs_options.username,
-        password=lakefs_options.password,
-    )
     rpath = f"{repository}/{temp_branch}/{random_file.name}"
 
     # try opening the remote file and writing to it

--- a/tests/test_ls.py
+++ b/tests/test_ls.py
@@ -1,16 +1,10 @@
 from lakefs_spec import LakeFSFileSystem
-from tests.conftest import LakeFSOptions
 
 
-def test_paginated_ls(lakefs_options: LakeFSOptions, repository: str) -> None:
+def test_paginated_ls(fs: LakeFSFileSystem, repository: str) -> None:
     """
     Check that all results of an ``ls`` call are returned independently of page size.
     """
-    fs = LakeFSFileSystem(
-        host=lakefs_options.host,
-        username=lakefs_options.username,
-        password=lakefs_options.password,
-    )
     resource = f"{repository}/main/"
 
     # default amount of 100 objects per page

--- a/tests/test_put_file.py
+++ b/tests/test_put_file.py
@@ -1,20 +1,14 @@
 from lakefs_spec import LakeFSFileSystem
-from tests.conftest import LakeFSOptions
 from tests.util import RandomFileFactory
 
 
 def test_put_with_default_commit_hook(
     random_file_factory: RandomFileFactory,
-    lakefs_options: LakeFSOptions,
+    fs: LakeFSFileSystem,
     repository: str,
     temp_branch: str,
 ) -> None:
-    fs = LakeFSFileSystem(
-        host=lakefs_options.host,
-        username=lakefs_options.username,
-        password=lakefs_options.password,
-        postcommit=True,
-    )
+    fs.postcommit = True
 
     random_file = random_file_factory.make()
 
@@ -32,18 +26,13 @@ def test_put_with_default_commit_hook(
 
 def test_no_change_postcommit(
     random_file_factory: RandomFileFactory,
-    lakefs_options: LakeFSOptions,
+    fs: LakeFSFileSystem,
     repository: str,
     temp_branch: str,
 ) -> None:
     # we just push without pre-checks, otherwise the no-diff scenario does not happen
-    fs = LakeFSFileSystem(
-        host=lakefs_options.host,
-        username=lakefs_options.username,
-        password=lakefs_options.password,
-        precheck_files=False,
-        postcommit=True,
-    )
+    fs.postcommit = True
+    fs.precheck_files = False
 
     random_file = random_file_factory.make()
 


### PR DESCRIPTION
This PR simplifies most tests by introducing a new fixture for the `LakeFSFileSystem` instance under test.

It also includes a docker-compose file for local development, which creates an ephemeral lakeFS quickstart instance with settings compatible to the defaults in the test fixtures.