### PR TITLE
Include setuptools-scm for version derivation from Git

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=45", "setuptools-scm[toml]>=6.2", "wheel"]
+requires = ["setuptools>=45", "setuptools-scm[toml]>=7.1", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools>=45", "setuptools-scm[toml]>=6.2", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -41,12 +41,7 @@ Repository = "https://github.com/appliedai-initiative/lakefs-spec.git"
 Issues = "https://github.com/appliedai-initiative/lakefs-spec/issues"
 
 [project.optional-dependencies]
-dev = [
-    "pre-commit>=3.3.3",
-    "pytest>=7.4.0",
-    "twine>=4.0.0",
-    "build>=0.10.0",
-]
+dev = ["pre-commit>=3.3.3", "pytest>=7.4.0", "twine>=4.0.0", "build>=0.10.0"]
 
 # Register lakeFS file system via the fsspec entry point
 [project.entry-points]
@@ -62,8 +57,8 @@ where = ["src"]
 [tool.setuptools.package-data]
 lakefs_spec = ["py.typed"]
 
-[tool.setuptools.dynamic]
-version = { attr = "lakefs_spec.version" }
+# Automatically determine version number from Git tags
+[tool.setuptools_scm]
 
 [tool.black]
 # Source https://github.com/psf/black#configuration-format

--- a/src/lakefs_spec/__init__.py
+++ b/src/lakefs_spec/__init__.py
@@ -1,3 +1,9 @@
+from importlib.metadata import PackageNotFoundError, version
+
 from .spec import LakeFSFile, LakeFSFileSystem
 
-version = "0.1.1"
+try:
+    __version__ = version("lakefs-spec")
+except PackageNotFoundError:
+    # package is not installed
+    pass


### PR DESCRIPTION
This commit adds [setuptools-scm](https://pypi.org/project/setuptools-scm/) as a build dependency in order to dynamically determine the version number of the package from Git tags.

This prevents inconsistencies between the versions in the package and the repository, which have already bitten us before.

Since we are already managing release versions through Git tags (by virtue of GitHub releases), determining the package version in this way seems like the least error-prone approach to me.

A test release has already been made based on this PR:

- GitHub release: https://github.com/appliedAI-Initiative/lakefs-spec/releases/tag/v0.1.0rc5
- CI: https://github.com/appliedAI-Initiative/lakefs-spec/actions/runs/5973519124/job/16205942347
- PyPI: https://pypi.org/project/lakefs-spec/0.1.0rc5/

Issue: #25