### PR TITLE
Improve flexibility of commithooks by adding more arguments

### DIFF
--- a/src/lakefs_spec/commithook.py
+++ b/src/lakefs_spec/commithook.py
@@ -1,12 +1,12 @@
-from enum import Enum
+from enum import StrEnum, auto
 from typing import Callable, NamedTuple
 
 from lakefs_client.models import CommitCreation, DiffList
 
 
-class FSEvent(Enum):
-    PUT = 1
-    RM = 2
+class FSEvent(StrEnum):
+    PUT = auto()
+    RM = auto()
 
 
 class HookContext(NamedTuple):
@@ -35,7 +35,7 @@ def Default(fs_event: FSEvent, ctx: HookContext) -> CommitCreation:
     elif fs_event == FSEvent.RM:
         action = "Remove"
     else:
-        raise ValueError(f"unexpected file system event {fs_event!r}")
+        raise ValueError(f"unexpected file system event {str(fs_event)!r}")
 
     message = f"""{action} file {ctx.resource}"""
 

--- a/src/lakefs_spec/commithook.py
+++ b/src/lakefs_spec/commithook.py
@@ -35,8 +35,8 @@ def Default(fs_event: FSEvent, ctx: HookContext) -> CommitCreation:
     elif fs_event == FSEvent.RM:
         action = "Remove"
     else:
-        raise ValueError(f"unexpected file system event {str(fs_event)!r}")
+        raise ValueError(f"unexpected file system event '{str(fs_event)}'")
 
-    message = f"""{action} file {ctx.resource}"""
+    message = f"{action} file {ctx.resource}"
 
     return CommitCreation(message=message)

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -22,7 +22,7 @@ from lakefs_client.exceptions import (
 )
 from lakefs_client.models import BranchCreation, ObjectStatsList
 
-from lakefs_spec.commithook import CommitHook, Default
+from lakefs_spec.commithook import CommitHook, Default, FSEvent, HookContext
 
 _DEFAULT_CALLBACK = NoOpCallback()
 
@@ -447,7 +447,8 @@ class LakeFSFileSystem(AbstractFileSystem):
                 logger.warning(f"No changes to commit on branch {branch!r}, aborting commit.")
                 return
 
-            commit_creation = self.commithook("put", resource)
+            ctx = HookContext(repository, branch, resource, diff)
+            commit_creation = self.commithook(FSEvent.PUT, ctx)
             self.client.commits_api.commit(
                 repository=repository, branch=branch, commit_creation=commit_creation
             )
@@ -475,7 +476,8 @@ class LakeFSFileSystem(AbstractFileSystem):
                 logger.warning(f"No changes to commit on branch {branch!r}, aborting commit.")
                 return
 
-            commit_creation = self.commithook("rm", resource)
+            ctx = HookContext(repository, branch, resource, diff)
+            commit_creation = self.commithook(FSEvent.RM, ctx)
             self.client.commits_api.commit(
                 repository=repository, branch=branch, commit_creation=commit_creation
             )


### PR DESCRIPTION
Adds the repository, the branch, and the diff that is being committed as direct inputs to the commit hook.

Also updates the docstring for the `CommitHook` type. Arguments were renamed from `event` to `fs_event`, and `rpath` to `resource`, respectively, to avoid confusion.

Fixes #27.