### PR TITLE
Simplify deps

### DIFF
--- a/dev-deps.lock
+++ b/dev-deps.lock
@@ -4,64 +4,34 @@
 #
 #    pip-compile --extra=dev --output-file=dev-deps.lock pyproject.toml
 #
-bleach==6.0.0
-    # via readme-renderer
 build==0.10.0
     # via lakefs-spec (pyproject.toml)
-certifi==2023.7.22
-    # via requests
 cfgv==3.3.1
     # via pre-commit
-charset-normalizer==3.2.0
-    # via requests
 distlib==0.3.7
     # via virtualenv
-docutils==0.20.1
-    # via readme-renderer
 filelock==3.12.2
     # via virtualenv
 fsspec==2023.6.0
     # via lakefs-spec (pyproject.toml)
 identify==2.5.26
     # via pre-commit
-idna==3.4
-    # via requests
-importlib-metadata==6.8.0
-    # via
-    #   keyring
-    #   twine
 iniconfig==2.0.0
     # via pytest
-jaraco-classes==3.3.0
-    # via keyring
-keyring==24.2.0
-    # via twine
 lakefs-client==0.107.0
     # via lakefs-spec (pyproject.toml)
-markdown-it-py==3.0.0
-    # via rich
-mdurl==0.1.2
-    # via markdown-it-py
-more-itertools==10.1.0
-    # via jaraco-classes
 nodeenv==1.8.0
     # via pre-commit
 packaging==23.1
     # via
     #   build
     #   pytest
-pkginfo==1.9.6
-    # via twine
 platformdirs==3.10.0
     # via virtualenv
 pluggy==1.2.0
     # via pytest
 pre-commit==3.3.3
     # via lakefs-spec (pyproject.toml)
-pygments==2.16.1
-    # via
-    #   readme-renderer
-    #   rich
 pyproject-hooks==1.0.0
     # via build
 pytest==7.4.0
@@ -70,35 +40,12 @@ python-dateutil==2.8.2
     # via lakefs-client
 pyyaml==6.0.1
     # via pre-commit
-readme-renderer==41.0
-    # via twine
-requests==2.31.0
-    # via
-    #   requests-toolbelt
-    #   twine
-requests-toolbelt==1.0.0
-    # via twine
-rfc3986==2.0.0
-    # via twine
-rich==13.5.2
-    # via twine
 six==1.16.0
-    # via
-    #   bleach
-    #   python-dateutil
-twine==4.0.2
-    # via lakefs-spec (pyproject.toml)
+    # via python-dateutil
 urllib3==2.0.4
-    # via
-    #   lakefs-client
-    #   requests
-    #   twine
+    # via lakefs-client
 virtualenv==20.24.2
     # via pre-commit
-webencodings==0.5.1
-    # via bleach
-zipp==3.16.2
-    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "lakefs-spec"
 description = "An fsspec implementation for lakeFS."
+keywords = ["lakeFS", "fsspec"]
 requires-python = ">=3.9"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 
-dependencies = ["fsspec >=2023.6.0", "lakefs-client>=0.105.0"]
+dependencies = ["fsspec>=2023.6.0", "lakefs-client>=0.105.0"]
 
 dynamic = ["version"]
 
@@ -41,7 +41,7 @@ Repository = "https://github.com/appliedai-initiative/lakefs-spec.git"
 Issues = "https://github.com/appliedai-initiative/lakefs-spec/issues"
 
 [project.optional-dependencies]
-dev = ["pre-commit>=3.3.3", "pytest>=7.4.0", "twine>=4.0.0", "build>=0.10.0"]
+dev = ["pre-commit>=3.3.3", "pytest>=7.4.0", "build>=0.10.0"]
 
 # Register lakeFS file system via the fsspec entry point
 [project.entry-points]


### PR DESCRIPTION
Since package publishing happens as part of CI exclusively, we don't need the `twine` dependency anymore.

Also, add the `keywords` metadata attribute to the package.