### PR TITLE
Add lakectl config support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dev = [
     "build>=0.10.0",
     "pytest-cov>=4.1.0",
 ]
+yaml = ["pyyaml"]
 
 # Register lakeFS file system via the fsspec entry point
 [project.entry-points]
@@ -85,6 +86,10 @@ pretty = true
 python_version = "3.11"
 strict_optional = false
 warn_unreachable = true
+
+[[tool.mypy.overrides]]
+module = ["yaml"]
+ignore_missing_imports = true
 
 [tool.ruff]
 # Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -45,12 +45,12 @@ class LakectlConfig(NamedTuple):
         except ModuleNotFoundError:
             return cls()
 
-        obj: dict[str, Any] = yaml.safe_load(Path(path).expanduser())
+        obj: dict[str, Any] = yaml.safe_load(path)
 
         # config struct schema (Golang backend code):
         # https://github.com/treeverse/lakeFS/blob/master/cmd/lakectl/cmd/root.go
         creds: dict[str, str] = obj.get("credentials", {})
-        server: dict[str, str] = obj.get("server")
+        server: dict[str, str] = obj.get("server", {})
         username = creds.get("access_key_id")
         password = creds.get("secret_access_key")
         host = server.get("endpoint_url")
@@ -219,8 +219,8 @@ class LakeFSFileSystem(AbstractFileSystem):
         """
         super().__init__()
 
-        if Path(configfile).expanduser().exists():
-            lakectl_config = LakectlConfig.read(configfile)
+        if (p := Path(configfile).expanduser()).exists():
+            lakectl_config = LakectlConfig.read(p)
         else:
             # empty config.
             lakectl_config = LakectlConfig()

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -7,7 +7,7 @@ import sys
 import warnings
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Generator, NamedTuple, Optional, Union
+from typing import Any, Generator, NamedTuple
 
 from fsspec.callbacks import NoOpCallback
 from fsspec.spec import AbstractBufferedFile, AbstractFileSystem
@@ -34,12 +34,12 @@ EmptyYield = Generator[None, None, None]
 
 
 class LakectlConfig(NamedTuple):
-    host: Optional[str] = None
-    username: Optional[str] = None
-    password: Optional[str] = None
+    host: str | None = None
+    username: str | None = None
+    password: str | None = None
 
     @classmethod
-    def read(cls, path: Union[str, Path]) -> "LakectlConfig":
+    def read(cls, path: str | Path) -> "LakectlConfig":
         try:
             import yaml
         except ModuleNotFoundError:
@@ -267,10 +267,10 @@ class LakeFSFileSystem(AbstractFileSystem):
     @contextmanager
     def scope(
         self,
-        postcommit: Optional[bool] = None,
-        precheck_files: Optional[bool] = None,
-        create_branch_ok: Optional[bool] = None,
-        source_branch: Optional[str] = None,
+        postcommit: bool | None = None,
+        precheck_files: bool | None = None,
+        create_branch_ok: bool | None = None,
+        source_branch: str | None = None,
     ) -> EmptyYield:
         """
         Creates a context manager scope in which the lakeFS file system behavior

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -45,7 +45,8 @@ class LakectlConfig(NamedTuple):
         except ModuleNotFoundError:
             return cls()
 
-        obj: dict[str, Any] = yaml.safe_load(path)
+        with open(path, "r") as f:
+            obj: dict[str, Any] = yaml.safe_load(f)
 
         # config struct schema (Golang backend code):
         # https://github.com/treeverse/lakeFS/blob/master/cmd/lakectl/cmd/root.go

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -4,7 +4,6 @@ import logging
 import os
 import re
 import sys
-import warnings
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Generator, NamedTuple
@@ -43,6 +42,11 @@ class LakectlConfig(NamedTuple):
         try:
             import yaml
         except ModuleNotFoundError:
+            logger.warning(
+                f"Configuration '{path}' exists, but cannot be read "
+                f"because the `pyyaml package` is not installed. "
+                f"To fix, run `pip install --upgrade pyyaml`.",
+            )
             return cls()
 
         with open(path, "r") as f:
@@ -558,11 +562,10 @@ class LakeFSFile(AbstractBufferedFile):
             **kwargs,
         )
         if mode == "wb":
-            warnings.warn(
+            logger.warning(
                 "Calling open() in write mode results in unbuffered file uploads, "
                 "because the lakeFS Python client does not support multipart uploads. "
-                "Note that uploading large files unbuffered can "
-                "have performance implications."
+                "Note that uploading large files unbuffered can have performance implications."
             )
             repository, branch, resource = parse(path)
             ensure_branch(self.fs.client, repository, branch, self.fs.source_branch)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Generator, TypeVar
 
 import pytest
+import yaml
 from lakefs_client import Configuration
 from lakefs_client.client import LakeFSClient
 from lakefs_client.models import BranchCreation, RepositoryCreation
@@ -107,3 +108,21 @@ def temp_branch(lakefs_client: LakeFSClient, repository: str) -> YieldFixture[st
 @pytest.fixture
 def random_file_factory(tmp_path: Path) -> RandomFileFactory:
     return RandomFileFactory(path=tmp_path)
+
+
+@pytest.fixture
+def temporary_lakectl_config() -> YieldFixture[str]:
+    d = {
+        "credentials": {"access_key_id": "hello", "secret_access_key": "world"},
+        "server": {"endpoint_url": "http://hello-world-xyz"},
+    }
+
+    loc = "~/.lakectl.yaml"
+    path = Path(loc).expanduser()
+
+    try:
+        with open(path, "w") as f:
+            yaml.dump(d, f)
+        yield loc
+    finally:
+        path.unlink()

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -1,3 +1,5 @@
+from pytest import MonkeyPatch
+
 from lakefs_spec import LakeFSFileSystem
 
 
@@ -20,3 +22,43 @@ def test_instance_caching(fs: LakeFSFileSystem) -> None:
 
     assert fs2._fs_token != fs._fs_token
     assert len(LakeFSFileSystem._cache) == 2
+
+
+def test_initialization(monkeypatch: MonkeyPatch, temporary_lakectl_config: str) -> None:
+    """
+    Verify the priority order of initialization in lakeFS file system:
+    1. direct arguments
+    2. environment variables
+    3. `lakectl` config file
+
+    NOTE: The configuration appends "/api/v1" to all hostnames by default.
+    """
+
+    # Verify behaviors in reverse priority order.
+    # Case 1: Instantiation from ~/.lakectl.yaml.
+    cfg_fs = LakeFSFileSystem()
+    config = cfg_fs.client._api.configuration
+    assert config.host == "http://hello-world-xyz/api/v1"
+    assert config.username == "hello"
+    assert config.password == "world"
+
+    monkeypatch.setenv("LAKEFS_HOST", "http://localhost:1000")
+    monkeypatch.setenv("LAKEFS_USERNAME", "my-user")
+    monkeypatch.setenv("LAKEFS_PASSWORD", "my-password-12345")
+
+    # Case 2: Instantiation from envvars.
+    # Clear the instance cache first, since we otherwise would get a cache hit
+    # due to the instantiation being the same as from `.lakectl.yaml` above.
+    LakeFSFileSystem._cache.clear()
+    envvar_fs = LakeFSFileSystem()
+    config = envvar_fs.client._api.configuration
+    assert config.host == "http://localhost:1000/api/v1"
+    assert config.username == "my-user"
+    assert config.password == "my-password-12345"
+
+    # Case 3: Explicit initialization.
+    fs = LakeFSFileSystem(host="http://lakefs.hello", username="my-user", password="my-password")
+    config = fs.client._api.configuration
+    assert config.host == "http://lakefs.hello/api/v1"
+    assert config.username == "my-user"
+    assert config.password == "my-password"


### PR DESCRIPTION
Assumes the default location (`~/.lakectl.yaml`), and loads the config file if it exists and YAML is installed.

If YAML is not installed (this is not a hard requirement), it is possible to install it via `python -m pip install lakefs-spec[yaml]`. This extra is added specifically for `lakectl` configuration file support.

Also ignores missing imports from `pyyaml` under mypy.

Closes #43.