### PR TITLE
Unpin lakefs-client dependency

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       lakefs:
-        image: treeverse/lakefs:0.107.0
+        image: treeverse/lakefs:0.108.0
         ports:
           - 8000:8000
         env:

--- a/hack/docker-compose.yml
+++ b/hack/docker-compose.yml
@@ -4,7 +4,7 @@ version: "3"
 
 services:
   lakefs:
-    image: treeverse/lakefs:0.107.0
+    image: treeverse/lakefs:0.108.0
     ports:
       - 8000:8000
     environment:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 
-dependencies = ["fsspec>=2023.6.0", "lakefs-client>=0.105.0,<0.108.0"]
+dependencies = ["fsspec>=2023.6.0", "lakefs-client>=0.105.0"]
 
 dynamic = ["version"]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,7 +20,7 @@ identify==2.5.27
     # via pre-commit
 iniconfig==2.0.0
     # via pytest
-lakefs-client==0.107.1
+lakefs-client==0.108.0
     # via lakefs-spec (pyproject.toml)
 nodeenv==1.8.0
     # via pre-commit

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 fsspec==2023.6.0
     # via lakefs-spec (pyproject.toml)
-lakefs-client==0.107.1
+lakefs-client==0.108.0
     # via lakefs-spec (pyproject.toml)
 python-dateutil==2.8.2
     # via lakefs-client


### PR DESCRIPTION
Issue: #47

This PR unpins the `lakefs-client` dependency, updating it to the latest release `0.108.0`.

Due to a breaking API change, the sidecars for testing (docker-compose locally, GH actions) needed to be updated in lockstep.