### PR TITLE
Bump multiple tools and dependencies to latest versions 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.286
+    rev: v0.0.287
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --extra=dev --output-file=requirements-dev.txt pyproject.toml
 #
-build==0.10.0
+build==1.0.0
     # via lakefs-spec (pyproject.toml)
 cfgv==3.4.0
     # via pre-commit
@@ -14,7 +14,7 @@ distlib==0.3.7
     # via virtualenv
 filelock==3.12.3
     # via virtualenv
-fsspec==2023.6.0
+fsspec==2023.9.0
     # via lakefs-spec (pyproject.toml)
 identify==2.5.27
     # via pre-commit
@@ -32,11 +32,11 @@ platformdirs==3.10.0
     # via virtualenv
 pluggy==1.3.0
     # via pytest
-pre-commit==3.3.3
+pre-commit==3.4.0
     # via lakefs-spec (pyproject.toml)
 pyproject-hooks==1.0.0
     # via build
-pytest==7.4.0
+pytest==7.4.1
     # via
     #   lakefs-spec (pyproject.toml)
     #   pytest-cov
@@ -50,7 +50,7 @@ six==1.16.0
     # via python-dateutil
 urllib3==2.0.4
     # via lakefs-client
-virtualenv==20.24.3
+virtualenv==20.24.4
     # via pre-commit
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --strip-extras pyproject.toml
 #
-fsspec==2023.6.0
+fsspec==2023.9.0
     # via lakefs-spec (pyproject.toml)
 lakefs-client==0.108.0
     # via lakefs-spec (pyproject.toml)


### PR DESCRIPTION
`fsspec` 2023.9 includes our filesystem in the registry, and should always be kept up to date.

Some other tools also had new releases, notably `build` to stable 1.0.0.