### PR TITLE
Add missing tests for `fs.exists()` and `fs.rm()`

### DIFF
--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -328,7 +328,7 @@ class LakeFSFileSystem(AbstractFileSystem):
     def exists(self, path, **kwargs):
         repository, ref, resource = parse(path)
         try:
-            self.client.objects_api.head_object(repository, ref, path)
+            self.client.objects_api.head_object(repository, ref, resource)
             return True
         except NotFoundException:
             return False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,6 +78,7 @@ def ensurerepo(lakefs_client: LakeFSClient) -> str:
             RepositoryCreation(
                 name=_TEST_REPO,
                 storage_namespace=storage_namespace,
+                sample_data=True,
             )
         )
     return _TEST_REPO

--- a/tests/test_exists.py
+++ b/tests/test_exists.py
@@ -1,0 +1,29 @@
+from lakefs_spec import LakeFSFileSystem
+from tests.util import RandomFileFactory
+
+
+def test_exists(fs: LakeFSFileSystem, repository: str) -> None:
+    """Test `fs.exists` on an existing file. Requires a populated repository."""
+
+    example_file = f"{repository}/main/README.md"
+    assert fs.exists(example_file)
+
+    nonexistent_file = f"{repository}/main/nonexistent.parquet"
+    assert not fs.exists(nonexistent_file)
+
+
+def test_exists_on_staged_file(
+    random_file_factory: RandomFileFactory,
+    fs: LakeFSFileSystem,
+    repository: str,
+    temp_branch: str,
+) -> None:
+
+    random_file = random_file_factory.make()
+
+    lpath = str(random_file)
+    rpath = f"{repository}/{temp_branch}/{random_file.name}"
+
+    # upload, verify existence.
+    fs.put(lpath, rpath)
+    assert fs.exists(rpath)

--- a/tests/test_exists.py
+++ b/tests/test_exists.py
@@ -18,7 +18,6 @@ def test_exists_on_staged_file(
     repository: str,
     temp_branch: str,
 ) -> None:
-
     random_file = random_file_factory.make()
 
     lpath = str(random_file)

--- a/tests/test_rm.py
+++ b/tests/test_rm.py
@@ -1,0 +1,31 @@
+from lakefs_spec import LakeFSFileSystem
+
+
+def test_rm(
+    fs: LakeFSFileSystem,
+    repository: str,
+    temp_branch: str,
+) -> None:
+    path = f"{repository}/{temp_branch}/README.md"
+
+    fs.rm(path)
+    assert not fs.exists(path)
+
+
+def test_rm_with_postcommit(
+    fs: LakeFSFileSystem,
+    repository: str,
+    temp_branch: str,
+) -> None:
+    with fs.scope(postcommit=True):
+        path = f"{repository}/{temp_branch}/README.md"
+
+        fs.rm(path)
+        assert not fs.exists(path)
+
+    commits = fs.client.refs_api.log_commits(
+        repository=repository,
+        ref=temp_branch,
+    )
+    latest_commit = commits.results[0]
+    assert latest_commit.message == "Remove file README.md"


### PR DESCRIPTION
The fact that these were necessary and overdue is spelled out by a254a8a8c85c5507146e89ff5da0ac2400711231, which fixes a bug that prevented `fs.exists()` from ever working correctly in the first place.

Also changes the test configuration to pre-populate the test repository with sample data, which is useful all around for upcoming tests, such as pandas integration tests.

Closes #53.