### PR TITLE
Wrap all API calls in `try-except`s

### DIFF
--- a/tests/test_lakefs_file.py
+++ b/tests/test_lakefs_file.py
@@ -1,3 +1,5 @@
+import pytest
+
 from lakefs_spec import LakeFSFileSystem
 from tests.util import RandomFileFactory
 
@@ -48,3 +50,10 @@ def test_lakefs_file_open_write(
 
     # round-trip assert.
     assert new_text == orig_text
+
+
+def test_lakefs_file_unknown_mode(fs: LakeFSFileSystem) -> None:
+    """Test that a NotImplementedError is raised on unknown mode encounter."""
+
+    with pytest.raises(NotImplementedError, match="unsupported mode .*"):
+        fs.open("hello.py", mode="ab")

--- a/tests/test_put_file.py
+++ b/tests/test_put_file.py
@@ -2,7 +2,6 @@ import random
 import string
 
 import pytest
-from lakefs_client.exceptions import NotFoundException
 
 from lakefs_spec import LakeFSFileSystem
 from tests.util import RandomFileFactory
@@ -97,5 +96,5 @@ def test_implicit_branch_creation(
     with fs.scope(create_branch_ok=False):
         another_non_existing_branch = "non-existing-" + "".join(random.choices(string.digits, k=8))
         rpath = f"{repository}/{another_non_existing_branch}/{random_file.name}"
-        with pytest.raises(NotFoundException):
+        with pytest.raises(FileNotFoundError):
             fs.put(lpath, rpath)


### PR DESCRIPTION
Also change tests to expect only Python-native errors.

Adds a test for unsupported file modes in `fs.open`.