### PR TITLE
Add tests for file operations with prechecks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
        types_or: [ python, pyi ]
        args: ["--ignore-missing-imports", "--scripts-are-modules"]
   - repo: https://github.com/psf/black
-    rev: 23.7.0
+    rev: 23.9.1
     hooks:
       - id: black
   - repo: https://github.com/pycqa/isort

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ If you do have to mix both methods, you can clear the instance cache like so:
 ```python
 from lakefs_spec import LakeFSFileSystem
 
-LakeFSFileSystem._cache.clear()
+LakeFSFileSystem.clear_instance_cache()
 ```
 
 ## Developing and contributing to `lakefs-spec`

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,7 @@ def lakefs_options() -> LakeFSOptions:
 
 @pytest.fixture
 def fs(lakefs_options: LakeFSOptions) -> LakeFSFileSystem:
+    LakeFSFileSystem.clear_instance_cache()
     return LakeFSFileSystem(**asdict(lakefs_options))
 
 


### PR DESCRIPTION
Verifies through an API counter that prechecks save redundant operations by not requesting unnecessary API calls on a checksum match.

Also bumps `black` to version v23.9.1 via `pre-commit autoupdate`.

Closes #57.