### PR TITLE
Add test for expected logs on missing YAML module

### DIFF
--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -39,9 +39,8 @@ class LakectlConfig(NamedTuple):
             import yaml
         except ModuleNotFoundError:
             logger.warning(
-                f"Configuration '{path}' exists, but cannot be read "
-                f"because the `pyyaml package` is not installed. "
-                f"To fix, run `pip install --upgrade pyyaml`.",
+                f"Configuration '{path}' exists, but cannot be read because the `pyyaml` package "
+                f"is not installed. To fix, run `python -m pip install --upgrade pyyaml`.",
             )
             return cls()
 


### PR DESCRIPTION
We emit a warning if `pyyaml` is not installed and the user has a `.lakectl.yaml` config file available. Add a test to verify that warning.