### PR TITLE
feat(fs.commit): Expose commit to FS via path

### DIFF
--- a/tests/test_commit.py
+++ b/tests/test_commit.py
@@ -1,0 +1,21 @@
+from lakefs_spec import LakeFSFileSystem
+from tests.util import RandomFileFactory
+
+
+def test_commit(
+    random_file_factory: RandomFileFactory, fs: LakeFSFileSystem, repository: str, temp_branch: str
+) -> None:
+    fs.postcommit = False
+    random_file = random_file_factory.make()
+
+    lpath = str(random_file)
+    rpath = f"{repository}/{temp_branch}/{random_file.name}"
+    fs.put(lpath, rpath)
+    fs.commit(rpath)
+
+    commits = fs.client.refs_api.log_commits(
+        repository=repository,
+        ref=temp_branch,
+    )
+    latest_commit = commits.results[0]  # commit log is ordered branch-tip-first
+    assert latest_commit.message == f"Add file {random_file.name}"


### PR DESCRIPTION
Expose a commit to the filesystem via the path to LakeFS. [Code](https://github.com/appliedAI-Initiative/lakefs-spec/pull/68/files#diff-f8235da430cb8c0f32975a91dcd263e02044b2621322a7e6c97182b53649ea1eR289).

Adresses parts of https://github.com/appliedAI-Initiative/lakefs-spec/issues/66.

# Other Changes 
- Renamed the previous `commit` function to `_commit` only for internal use
- Test for the new Commit function