### PR TITLE
Pipe `**kwargs` to client API calls, make `precheck_files` a file op keyword argument

### DIFF
--- a/tests/test_checksum.py
+++ b/tests/test_checksum.py
@@ -33,8 +33,5 @@ def test_checksum_matching(
     assert counter.count("objects_api.upload_object") == 1
 
     # force overwrite this time, assert the `upload` API was called again
-    with fs.scope(precheck_files=False):
-        fs.put_file(lpath, rpath)
-
-    assert fs.precheck_files is True
+    fs.put_file(lpath, rpath, precheck=False)
     assert counter.count("objects_api.upload_object") == 2

--- a/tests/test_get_file.py
+++ b/tests/test_get_file.py
@@ -49,8 +49,7 @@ def test_get_client_caching(
     random_file_factory: RandomFileFactory, fs: LakeFSFileSystem, repository: str, temp_branch: str
 ) -> None:
     """
-    Tests that the `precheck_files` branch stops a download of a previously uploaded
-    identical file via checksum matching.
+    Tests that `precheck=True` prevents the download of a previously uploaded identical file.
     """
     fs.client, counter = with_counter(fs.client)
 

--- a/tests/test_put_file.py
+++ b/tests/test_put_file.py
@@ -104,8 +104,7 @@ def test_put_client_caching(
     random_file_factory: RandomFileFactory, fs: LakeFSFileSystem, repository: str, temp_branch: str
 ) -> None:
     """
-    Tests that the `precheck_files` branch stops a second upload of an
-    identical file via checksum matching.
+    Tests that `precheck=True` prevents a second upload of an identical file by matching checksums.
     """
     fs.client, counter = with_counter(fs.client)
 


### PR DESCRIPTION
This is what the keyword arguments were designed to do in the abstract file system base class, so it is only natural to do this. Also implicitly enables pre-signed URL support by passing `presign=True` to the `fs.ls` and `fs.get_file` methods.

Since the switch is scoped so narrowly to file transfers, take up `precheck` (formerly `precheck_files`) into the `fs.{get|put}_file` signatures as a keyword argument.

The client-side caching portion of the readme was rephrased to account for this new mode of operation.