### PR TITLE
Call `objects_api.stat_object` endpoint in case of file in `fs.info`

### DIFF
--- a/tests/test_checksum.py
+++ b/tests/test_checksum.py
@@ -27,9 +27,8 @@ def test_checksum_matching(
         # this test sometimes fails because of a race condition in the client
         time.sleep(0.1)
 
-    # we expect to get one `ls` call per upload attempt,
-    # but only one actual upload.
-    assert counter.count("objects_api.list_objects") == len(blocksizes) + 1
+    # we expect to get one `info` call per upload attempt, but only one actual upload.
+    assert counter.count("objects_api.stat_object") == len(blocksizes) + 1
     assert counter.count("objects_api.upload_object") == 1
 
     # force overwrite this time, assert the `upload` API was called again

--- a/tests/test_get_file.py
+++ b/tests/test_get_file.py
@@ -61,6 +61,5 @@ def test_get_client_caching(
 
     # try to get file, should not initiate a download due to checksum matching.
     fs.get(rpath, lpath)
-    print(list(counter.named_counts()))
     assert counter.count("objects_api.upload_object") == 1
     assert counter.count("objects_api.get_object") == 0

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -1,0 +1,23 @@
+import pytest
+
+from lakefs_spec import LakeFSFileSystem
+
+
+def test_info_on_directory(fs: LakeFSFileSystem, repository: str) -> None:
+    """
+    Check that an `fs.info` call on a trailing-slash resource yields a directory.
+    """
+    resource = f"{repository}/main/"
+    res = fs.info(resource)
+
+    assert res["type"] == "directory"
+
+
+def test_info_on_nonexistent_directory(fs: LakeFSFileSystem, repository: str) -> None:
+    """
+    Check that a nonexistent directory raises a FileNotFoundError in `fs.info`.
+    """
+    resource = f"{repository}/main/blabla/"
+
+    with pytest.raises(FileNotFoundError):
+        fs.info(resource)


### PR DESCRIPTION
It is wasteful to always get the object list from `objects_api.list_object`, and might be slower for buckets/repos with lots of objects.

Hence, if we decide that the input to `fs.info` is a file (heuristic: input does NOT end on slash), we call the `objects_api.stat_object` endpoint instead.

Judging from an earlier debugging session, when requesting file info, this also saves some more API calls that would happen as a ripple effect from `fs.ls`.