### PR TITLE
Fix local S3 docker compose by switching to host networking

### DIFF
--- a/hack/lakefs-s3-local.yml
+++ b/hack/lakefs-s3-local.yml
@@ -5,23 +5,23 @@ version: "3"
 services:
   seaweedfs:
       container_name: sandbox-s3
-      image: chrislusf/seaweedfs:3.45
+      image: chrislusf/seaweedfs:3.56
+      ports:
+        - 9001:9001
+      network_mode: host
       command: server -ip.bind 0.0.0.0 -master.volumeSizeLimitMB=1024 -volume.port=9000 -filer.collection=sandbox -s3 -s3.port 9001 -s3.config=/etc/seaweedfs/s3.json -s3.allowEmptyFolder=true -s3.allowDeleteBucketNotEmpty=true
       volumes:
           - seaweedfs-data:/data
           - ./config/s3.json:/etc/seaweedfs/s3.json
-      networks:
-        - sandbox
       restart: always
 
   lakefs:
-    image: treeverse/lakefs:0.108.0
+    image: treeverse/lakefs:0.110.0
     ports:
       - 8000:8000
+    network_mode: host
     depends_on:
       - seaweedfs
-    networks:
-      - sandbox
     environment:
       LAKEFS_INSTALLATION_USER_NAME: "quickstart"
       LAKEFS_INSTALLATION_ACCESS_KEY_ID: "AKIAIOSFOLQUICKSTART"
@@ -30,15 +30,11 @@ services:
       LAKEFS_AUTH_ENCRYPT_SECRET_KEY: "THIS_MUST_BE_CHANGED_IN_PRODUCTION"
       LAKEFS_BLOCKSTORE_TYPE: s3
       LAKEFS_BLOCKSTORE_S3_FORCE_PATH_STYLE: true
-      LAKEFS_BLOCKSTORE_S3_ENDPOINT: http://seaweedfs:9001
+      LAKEFS_BLOCKSTORE_S3_ENDPOINT: http://127.0.0.1:9001
       LAKEFS_BLOCKSTORE_S3_DISCOVER_BUCKET_REGION: false
       LAKEFS_BLOCKSTORE_S3_CREDENTIALS_ACCESS_KEY_ID: sandbox
       LAKEFS_BLOCKSTORE_S3_CREDENTIALS_SECRET_ACCESS_KEY: sandbox
-      LAKEFS_BLOCKSTORE_DEFAULT_NAMESPACE_PREFIX: s3://sandbox/lakefs
+      LAKEFS_BLOCKSTORE_DEFAULT_NAMESPACE_PREFIX: s3://sandbox/lakefs/
 
 volumes:
     seaweedfs-data: {}
-
-networks:
-    sandbox:
-        driver: bridge


### PR DESCRIPTION
Unbreaks the `http://seaweedfs:` resolve failures in the lakeFS client by explicitly setting the IPv4 as S3 endpoint, and exposing port 9001 on the SeaweedFS container.