### PR TITLE
Fix buffer deletes on upload

### DIFF
--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -382,7 +382,7 @@ class LakeFSFileSystem(AbstractFileSystem):
             self,
             path=path,
             mode=mode,
-            block_size=block_size,
+            block_size=block_size or self.blocksize,
             autocommit=autocommit,
             cache_options=cache_options,
             **kwargs,


### PR DESCRIPTION
Otherwise, we throw away a full buffer because we do not upload until `final=True` (force-flush/file close).

Since our case is sufficiently different from the buffered standard implementation, we just override `flush` instead of tweaking the `_upload_chunk`.

Also, pipe file system blocksize to opened files - otherwise, the user has no control over the block size in a read (the write is unbuffered, anyway).