### PR TITLE
Implement `LakeFSFilesystem.cp_file`

### DIFF
--- a/src/lakefs_spec/hooks.py
+++ b/src/lakefs_spec/hooks.py
@@ -8,6 +8,7 @@ from lakefs_spec.util import parse
 
 class FSEvent(StrEnum):
     CHECKSUM = auto()
+    CP_FILE = auto()
     EXISTS = auto()
     GET_FILE = auto()
     GET = auto()

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -1,0 +1,25 @@
+from typing import Any
+
+from lakefs_spec import LakeFSFileSystem
+from tests.util import RandomFileFactory
+
+
+def test_copy(
+    random_file_factory: RandomFileFactory,
+    fs: LakeFSFileSystem,
+    repository: str,
+    temp_branch: str,
+    temporary_branch_context: Any,
+) -> None:
+    random_file = random_file_factory.make()
+
+    lpath = str(random_file)
+    rpath = f"{repository}/{temp_branch}/{random_file.name}"
+
+    fs.put(lpath, rpath)
+    assert fs.exists(rpath)
+
+    with temporary_branch_context("new-copy-test") as b:
+        new_rpath = f"{repository}/{b}/{random_file.name}"
+        fs.cp_file(rpath, new_rpath)
+        assert fs.exists(new_rpath)

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -1,7 +1,9 @@
 from typing import Any
 
+import pytest
+
 from lakefs_spec import LakeFSFileSystem
-from tests.util import RandomFileFactory
+from tests.util import RandomFileFactory, with_counter
 
 
 def test_copy(
@@ -23,3 +25,20 @@ def test_copy(
         new_rpath = f"{repository}/{b}/{random_file.name}"
         fs.cp_file(rpath, new_rpath)
         assert fs.exists(new_rpath)
+
+
+def test_copy_edge_cases(
+    fs: LakeFSFileSystem,
+    repository: str,
+    temp_branch: str,
+) -> None:
+    fs.client, counter = with_counter(fs.client)
+
+    path = f"{repository}/main/lakes.parquet"
+
+    fs.cp_file(path, path)
+
+    assert counter.count("objects_api.copy_object") == 0
+
+    with pytest.raises(ValueError, match="can only copy objects within a repository.*"):
+        fs.cp_file(path, "my-repo/main/lakes.parquet")


### PR DESCRIPTION
A first implementation, directly calls into `objects_api.copy_object` after some input validation.

Only allows copies within a repo, since that limitation is imposed by the lakeFS client.

Does not check for a protocol, assumes string paths.

Adds a test as well.

Closes #79.