### PR TITLE
Add file upload and download events and corresponding `LakeFSFile` hooks

### DIFF
--- a/src/lakefs_spec/hooks.py
+++ b/src/lakefs_spec/hooks.py
@@ -9,6 +9,8 @@ from lakefs_spec.util import parse
 class FSEvent(StrEnum):
     CHECKSUM = auto()
     EXISTS = auto()
+    FILEDOWNLOAD = auto()
+    FILEUPLOAD = auto()
     GET_FILE = auto()
     GET = auto()
     INFO = auto()


### PR DESCRIPTION
Provides support for file read events (`mode == "rb"`) and changes the hook event from `PUT_FILE` to the newly created `FILEUPLOAD`.

Closes #83.