### PR TITLE
Implement directory listings caching for `ls`

### DIFF
--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -379,15 +379,6 @@ class LakeFSFileSystem(AbstractFileSystem):
         if info and pp in self.dircache:
             # ls info has files not in cache, so we update them in the cache entry.
             cache_entry = self.dircache[pp]
-            for obj in info:
-                try:
-                    names = [e["name"] for e in cache_entry]
-                    idx = names.index(obj["name"])
-                    # remove stale info in entry
-                    cache_entry.pop(idx)
-                except ValueError:
-                    pass
-
             # extend the entry by the new ls results
             cache_entry.extend(info)
             self.dircache[pp] = sorted(cache_entry, key=operator.itemgetter("name"))

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -375,15 +375,17 @@ class LakeFSFileSystem(AbstractFileSystem):
                     )
 
         # cache the info if not empty.
-        pp = self._parent(prefix)
-        if info and pp in self.dircache:
-            # ls info has files not in cache, so we update them in the cache entry.
-            cache_entry = self.dircache[pp]
-            # extend the entry by the new ls results
-            cache_entry.extend(info)
-            self.dircache[pp] = sorted(cache_entry, key=operator.itemgetter("name"))
-        elif info and pp not in self.dircache:
-            self.dircache[pp] = info
+        if info:
+            # assumes that the returned info is name-sorted.
+            pp = self._parent(info[0]["name"])
+            if pp in self.dircache:
+                # ls info has files not in cache, so we update them in the cache entry.
+                cache_entry = self.dircache[pp]
+                # extend the entry by the new ls results
+                cache_entry.extend(info)
+                self.dircache[pp] = sorted(cache_entry, key=operator.itemgetter("name"))
+            else:
+                self.dircache[pp] = info
 
         if not detail:
             info = [o["name"] for o in info]

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -377,18 +377,19 @@ class LakeFSFileSystem(AbstractFileSystem):
         # cache the info if not empty.
         pp = self._parent(prefix)
         if info and pp in self.dircache:
-            # ls info has files not in cache, so we add/update them in the cache entry.
+            # ls info has files not in cache, so we update them in the cache entry.
             cache_entry = self.dircache[pp]
             for obj in info:
                 try:
                     names = [e["name"] for e in cache_entry]
                     idx = names.index(obj["name"])
+                    # remove stale info in entry
                     cache_entry.pop(idx)
-                    cache_entry.insert(idx, obj)
-                except IndexError:
-                    # file has been newly added, append and sort by name.
-                    cache_entry.append(obj)
+                except ValueError:
+                    pass
 
+            # extend the entry by the new ls results
+            cache_entry.extend(info)
             self.dircache[pp] = sorted(cache_entry, key=operator.itemgetter("name"))
         elif info and pp not in self.dircache:
             self.dircache[pp] = info

--- a/tests/test_ls.py
+++ b/tests/test_ls.py
@@ -66,7 +66,6 @@ def test_ls_stale_cache_entry(
 def test_ls_no_detail(fs: LakeFSFileSystem, repository: str) -> None:
     fs.client, counter = with_counter(fs.client)
 
-    # TODO: This fails without the trailing slash - because of `cls._parent` (?).
     resource = f"{repository}/main/data"
 
     expected = ["data/lakes.source.md"]
@@ -77,3 +76,9 @@ def test_ls_no_detail(fs: LakeFSFileSystem, repository: str) -> None:
     # ...as well as the cache fetch.
     assert fs.ls(resource, detail=False) == expected
     assert counter.count("objects_api.list_objects") == 1
+
+    # test the same thing with a subfolder + file prefix
+    resource = f"{repository}/main/images/duckdb"
+    fs.ls(resource, detail=False)
+
+    assert list(fs.dircache.keys()) == ["data", "images"]

--- a/tests/test_ls.py
+++ b/tests/test_ls.py
@@ -1,4 +1,5 @@
 from lakefs_spec import LakeFSFileSystem
+from tests.util import with_counter
 
 
 def test_paginated_ls(fs: LakeFSFileSystem, repository: str) -> None:
@@ -13,3 +14,21 @@ def test_paginated_ls(fs: LakeFSFileSystem, repository: str) -> None:
     for pagesize in [2, 5, 10, 50]:
         paged_results = fs.ls(resource, amount=pagesize)
         assert paged_results == all_results
+
+
+def test_ls_caching(fs: LakeFSFileSystem, repository: str) -> None:
+    """
+    Check that ls calls are properly cached.
+    """
+    fs.client, counter = with_counter(fs.client)
+
+    testdir = "data"
+    resource = f"{repository}/main/{testdir}/"
+
+    for _ in range(2):
+        fs.ls(resource)
+        assert len(fs.dircache) == 1
+        assert tuple(fs.dircache.keys()) == (testdir,)
+
+    # assert the second `ls` call hits the cache
+    assert counter.count("objects_api.list_objects") == 1

--- a/tests/test_ls.py
+++ b/tests/test_ls.py
@@ -48,7 +48,6 @@ def test_ls_stale_cache_entry(
 
     fs.ls(resource)
     assert counter.count("objects_api.list_objects") == 1
-    assert len(fs.dircache) == 1
     assert tuple(fs.dircache.keys()) == ("data",)
 
     cache_entry = fs.dircache["data"]
@@ -62,3 +61,19 @@ def test_ls_stale_cache_entry(
     assert counter.count("objects_api.list_objects") == 2
     # is the file now added to the cache entry?
     assert res[0] in cache_entry
+
+
+def test_ls_no_detail(fs: LakeFSFileSystem, repository: str) -> None:
+    fs.client, counter = with_counter(fs.client)
+
+    # TODO: This fails without the trailing slash - because of `cls._parent` (?).
+    resource = f"{repository}/main/data"
+
+    expected = ["data/lakes.source.md"]
+    # first, verify the API fetch does the expected...
+    assert fs.ls(resource, detail=False) == expected
+    assert list(fs.dircache.keys()) == ["data"]
+
+    # ...as well as the cache fetch.
+    assert fs.ls(resource, detail=False) == expected
+    assert counter.count("objects_api.list_objects") == 1


### PR DESCRIPTION
Caches results of `fs.ls` calls in the class' `DirCache` instance.

As an added bonus, if a file is requested by `fs.ls` that has a cache entry for its parent, but is not yet found in the cache, this implementation will fetch those files and append them in the correct place in the existing cache entry. This "hot-reloading" of cache entries is a little more robust than just raising an exception and leaving the user to manually list the objects again.

Adds a test which verifies that the cache is hit on two identical `fs.ls` calls.

Does not assume cache size control or TTL, so this only checks a cache hit in the default configuration.

Closes #80.