### PR TITLE
Add new `client_helper` functions

### DIFF
--- a/src/lakefs_spec/client_helpers.py
+++ b/src/lakefs_spec/client_helpers.py
@@ -3,8 +3,8 @@ import sys
 
 from lakefs_client.client import LakeFSClient
 from lakefs_client.model.commit_creation import CommitCreation
-from lakefs_client.model.tag_creation import TagCreation
 from lakefs_client.model.revert_creation import RevertCreation
+from lakefs_client.model.tag_creation import TagCreation
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -28,23 +28,26 @@ def commit(
 
     client.commits_api.commit(repository=repository, branch=branch, commit_creation=commit_creation)
 
-def create_tag(client: LakeFSClient, repository: str, ref:str, tag:str) -> None:
+
+def create_tag(client: LakeFSClient, repository: str, ref: str, tag: str) -> None:
     tag_creation = TagCreation(tag, ref=ref)
     client.tags_api.create_tag(repository=repository, tag_creation=tag_creation)
 
-def get_tags_and_commits(client: LakeFSClient, repository: str) -> None: 
+
+def get_tags(client: LakeFSClient, repository: str) -> dict:
     return client.tags_api.list_tags(repository=repository)
 
-def merge(client: LakeFSClient,
-    repository: str,
-    source_ref: str,
-    target_branch: str) -> None:
 
-    diff = client.refs_api.diff_refs(repository=repository, left_ref=target_branch, right_ref=source_ref)
+def merge(client: LakeFSClient, repository: str, source_ref: str, target_branch: str) -> None:
+    diff = client.refs_api.diff_refs(
+        repository=repository, left_ref=target_branch, right_ref=source_ref
+    )
     if not diff.results:
         logger.warning("No difference between source and target. Aborting merge.")
         return
-    client.refs_api.merge_into_branch(repository=repository, source_ref=source_ref, destination_branch=target_branch) 
+    client.refs_api.merge_into_branch(
+        repository=repository, source_ref=source_ref, destination_branch=target_branch
+    )
 
 
 def revert(client: LakeFSClient, repository: str, branch: str, parent_number: int = 1) -> None:

--- a/src/lakefs_spec/client_helpers.py
+++ b/src/lakefs_spec/client_helpers.py
@@ -3,6 +3,8 @@ import sys
 
 from lakefs_client.client import LakeFSClient
 from lakefs_client.model.commit_creation import CommitCreation
+from lakefs_client.model.tag_creation import TagCreation
+from lakefs_client.model.revert_creation import RevertCreation
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -25,3 +27,36 @@ def commit(
     commit_creation = CommitCreation(message=message, metadata=metadata or {})
 
     client.commits_api.commit(repository=repository, branch=branch, commit_creation=commit_creation)
+
+def create_tag(client: LakeFSClient, repository: str, ref:str, tag:str) -> None:
+    tag_creation = TagCreation(tag, ref=ref)
+    client.tags_api.create_tag(repository=repository, tag_creation=tag_creation)
+
+def get_tags_and_commits(client: LakeFSClient, repository: str) -> None: 
+    return client.tags_api.list_tags(repository=repository)
+
+def merge(client: LakeFSClient,
+    repository: str,
+    source_ref: str,
+    target_branch: str) -> None:
+
+    diff = client.refs_api.diff_refs(repository=repository, left_ref=target_branch, right_ref=source_ref)
+    if not diff.results:
+        logger.warning("No difference between source and target. Aborting merge.")
+        return
+    client.refs_api.merge_into_branch(repository=repository, source_ref=source_ref, destination_branch=target_branch) 
+
+
+def revert(client: LakeFSClient, repository: str, branch: str, parent_number: int = 1) -> None:
+    """Reverts the commit on the specified branch to the parent specified by parent_number.
+
+    Args:
+        client (LakeFSClient): The client to interact with.
+        repository (str): Repository in which the specified branch is located.
+        branch (str): Branch on which the commit should be reverted.
+        parent_number (int, optional): If there are multiple parents to a commit, specify to which parent the commit should be reverted. Index starts at 1. Defaults to 1.
+    """
+    revert_creation = RevertCreation(ref=branch, parent_number=parent_number)
+    client.branches_api.revert_branch(
+        repository=repository, branch=branch, revert_creation=revert_creation
+    )

--- a/tests/test_client_helpers.py
+++ b/tests/test_client_helpers.py
@@ -1,0 +1,114 @@
+import uuid
+from typing import Any
+
+import pytest
+
+import lakefs_spec.client_helpers as client_helpers
+from lakefs_spec import LakeFSFileSystem
+from tests.util import RandomFileFactory
+
+
+def test_create_tag(
+    random_file_factory: RandomFileFactory, fs: LakeFSFileSystem, repository: str, temp_branch: str
+) -> None:
+    random_file = random_file_factory.make()
+    lpath = str(random_file)
+    rpath = f"{repository}/{temp_branch}/{random_file.name}"
+    fs.put(lpath, rpath, precheck=False)
+    client_helpers.commit(
+        client=fs.client, repository=repository, branch=temp_branch, message="Commit File Factory"
+    )
+    try:
+        tag_name = f"Change_{uuid.uuid4()}"
+        client_helpers.create_tag(
+            client=fs.client, repository=repository, ref=temp_branch, tag=tag_name
+        )
+
+        assert any(
+            commit.get("id") == tag_name
+            for commit in fs.client.tags_api.list_tags(repository).results
+        )
+    finally:
+        fs.client.tags_api.delete_tag(repository=repository, tag=tag_name)
+
+
+def test_merge_into_branch(
+    random_file_factory: RandomFileFactory,
+    fs: LakeFSFileSystem,
+    repository: str,
+    temp_branch: str,
+    temporary_branch_context: Any,
+) -> None:
+    random_file = random_file_factory.make()
+
+    with temporary_branch_context("merge-into-branch-test") as new_branch:
+        source_ref = f"{repository}/{new_branch}/{random_file.name}"
+        with fs.scope(create_branch_ok=True):
+            fs.put(str(random_file), source_ref)
+            client_helpers.commit(
+                client=fs.client,
+                repository=repository,
+                branch=new_branch,
+                message="Commit new file",
+            )
+
+        assert (
+            len(
+                fs.client.refs_api.diff_refs(
+                    repository=repository, left_ref=temp_branch, right_ref=new_branch
+                ).results
+            )
+            > 0
+        )
+        client_helpers.merge(
+            client=fs.client,
+            repository=repository,
+            source_ref=new_branch,
+            target_branch=temp_branch,
+        )
+        assert (
+            len(
+                fs.client.refs_api.diff_refs(
+                    repository=repository, left_ref=temp_branch, right_ref=new_branch
+                ).results
+            )
+            == 0
+        )
+
+
+def test_merge_into_branch_aborts_on_no_diff(
+    caplog: pytest.LogCaptureFixture, fs: LakeFSFileSystem, repository: str, temp_branch: str
+) -> None:
+    client_helpers.merge(
+        client=fs.client, repository=repository, source_ref="main", target_branch=temp_branch
+    )
+    assert caplog.records[0].message == "No difference between source and target. Aborting merge."
+
+
+def test_revert(
+    fs: LakeFSFileSystem, random_file_factory: RandomFileFactory, repository: str, temp_branch: str
+) -> None:
+    random_file = random_file_factory.make()
+    source_ref = f"{repository}/{temp_branch}/{random_file.name}"
+    with fs.scope(create_branch_ok=True):
+        fs.put(str(random_file), source_ref)
+        client_helpers.commit(
+            client=fs.client, repository=repository, branch=temp_branch, message="Commit new file"
+        )
+    assert (
+        len(
+            fs.client.refs_api.diff_refs(
+                repository=repository, left_ref="main", right_ref=temp_branch
+            ).results
+        )
+        > 0
+    )
+    client_helpers.revert(client=fs.client, repository=repository, branch=temp_branch)
+    assert (
+        len(
+            fs.client.refs_api.diff_refs(
+                repository=repository, left_ref="main", right_ref=temp_branch
+            ).results
+        )
+        == 0
+    )


### PR DESCRIPTION
Add `client_helper` functions for convenience to use the lakeFS client. Add tests for these functions.

Closes https://github.com/appliedAI-Initiative/lakefs-spec/issues/82 by implementing
- [x] Revert
- [x] Add tag
- [x] Get Tags and Commits
- [x] Create Tag (and point to commit) 