### PR TITLE
Add rev-parse client helper

### DIFF
--- a/src/lakefs_spec/client_helpers.py
+++ b/src/lakefs_spec/client_helpers.py
@@ -76,10 +76,10 @@ def rev_parse(
         raise ValueError(f"Parent cannot be negative, got {parent}")
     try:
         revisions = client.refs_api.log_commits(
-            repository=repository, ref=ref, limit=2 * (parent + 1)
+            repository=repository, ref=ref, limit=True, amount=2 * (parent + 1)
         ).results
     except NotFoundException:
         raise RuntimeError(
-            "{ref!r} does not match any revision in lakeFS repository {repository!r}"
+            f"{ref!r} does not match any revision in lakeFS repository {repository!r}"
         )
     return revisions[parent].id

--- a/src/lakefs_spec/client_helpers.py
+++ b/src/lakefs_spec/client_helpers.py
@@ -78,8 +78,12 @@ def rev_parse(
         revisions = client.refs_api.log_commits(
             repository=repository, ref=ref, limit=True, amount=2 * (parent + 1)
         ).results
+        if len(revisions) <= parent:
+            raise ValueError(
+                f"cannot fetch revision {ref}~{parent}: {ref} only has {len(revisions)} parents"
+            )
+        return revisions[parent].id
     except NotFoundException:
         raise RuntimeError(
             f"{ref!r} does not match any revision in lakeFS repository {repository!r}"
         )
-    return revisions[parent].id

--- a/src/lakefs_spec/client_helpers.py
+++ b/src/lakefs_spec/client_helpers.py
@@ -79,7 +79,7 @@ def rev_parse(
             repository=repository, ref=ref, limit=True, amount=2 * (parent + 1)
         ).results
         if len(revisions) <= parent:
-            raise ValueError(
+            raise IndexError(
                 f"cannot fetch revision {ref}~{parent}: {ref} only has {len(revisions)} parents"
             )
         return revisions[parent].id

--- a/src/lakefs_spec/client_helpers.py
+++ b/src/lakefs_spec/client_helpers.py
@@ -79,7 +79,7 @@ def rev_parse(
             repository=repository, ref=ref, limit=True, amount=2 * (parent + 1)
         ).results
         if len(revisions) <= parent:
-            raise IndexError(
+            raise ValueError(
                 f"cannot fetch revision {ref}~{parent}: {ref} only has {len(revisions)} parents"
             )
         return revisions[parent].id

--- a/tests/test_client_helpers.py
+++ b/tests/test_client_helpers.py
@@ -157,7 +157,7 @@ def test_rev_parse_error_on_parent_does_not_exist(
     n_commits = len(fs.client.refs_api.log_commits(repository=repository, ref=temp_branch).results)
     non_existent_parent = n_commits + 1
     with pytest.raises(
-        IndexError,
+        ValueError,
         match=f"cannot fetch revision {temp_branch}~{non_existent_parent}: {temp_branch} only has {n_commits} parents",
     ):
         client_helpers.rev_parse(

--- a/tests/test_client_helpers.py
+++ b/tests/test_client_helpers.py
@@ -149,3 +149,17 @@ def test_rev_parse_error_on_commit_not_found(fs: LakeFSFileSystem, repository: s
         client_helpers.rev_parse(
             client=fs.client, repository=repository, ref=non_existent_ref, parent=0
         )
+
+
+def test_rev_parse_error_on_parent_does_not_exist(
+    fs: LakeFSFileSystem, repository: str, temp_branch: str
+) -> None:
+    n_commits = len(fs.client.refs_api.log_commits(repository=repository, ref=temp_branch).results)
+    non_existent_parent = n_commits + 1
+    with pytest.raises(
+        ValueError,
+        match=f"cannot fetch revision {temp_branch}~{non_existent_parent}: {temp_branch} only has {n_commits} parents",
+    ):
+        client_helpers.rev_parse(
+            client=fs.client, repository=repository, ref=temp_branch, parent=non_existent_parent
+        )

--- a/tests/test_client_helpers.py
+++ b/tests/test_client_helpers.py
@@ -157,7 +157,7 @@ def test_rev_parse_error_on_parent_does_not_exist(
     n_commits = len(fs.client.refs_api.log_commits(repository=repository, ref=temp_branch).results)
     non_existent_parent = n_commits + 1
     with pytest.raises(
-        ValueError,
+        IndexError,
         match=f"cannot fetch revision {temp_branch}~{non_existent_parent}: {temp_branch} only has {n_commits} parents",
     ):
         client_helpers.rev_parse(


### PR DESCRIPTION
Very small PR adding the `rev-parse` client helper. 

Did not include tests as it would essentially be testing `lakeFS client` code.