### PR TITLE
Remove stdout handlers from module loggers

### DIFF
--- a/src/lakefs_spec/client_helpers.py
+++ b/src/lakefs_spec/client_helpers.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 
 from lakefs_client.client import LakeFSClient
 from lakefs_client.model.commit_creation import CommitCreation
@@ -8,7 +7,6 @@ from lakefs_client.model.tag_creation import TagCreation
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
-logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 def commit(

--- a/src/lakefs_spec/config.py
+++ b/src/lakefs_spec/config.py
@@ -1,11 +1,9 @@
 import logging
-import sys
 from pathlib import Path
 from typing import Any, NamedTuple
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
-logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
 class LakectlConfig(NamedTuple):

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -3,7 +3,6 @@ import io
 import logging
 import operator
 import os
-import sys
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Generator
@@ -25,7 +24,6 @@ _DEFAULT_CALLBACK = NoOpCallback()
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
-logger.addHandler(logging.StreamHandler(sys.stdout))
 
 EmptyYield = Generator[None, None, None]
 


### PR DESCRIPTION
Otherwise, loggers in user code duplicate log entries. Instead, leave it to the user to decide where to log.