### PR TITLE
Update Python development dependencies and lakeFS docker image tags

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       lakefs:
-        image: treeverse/lakefs:0.110.0
+        image: treeverse/lakefs:0.112.1
         ports:
           - 8000:8000
         env:

--- a/hack/docker-compose.yml
+++ b/hack/docker-compose.yml
@@ -4,7 +4,7 @@ version: "3"
 
 services:
   lakefs:
-    image: treeverse/lakefs:0.110.0
+    image: treeverse/lakefs:0.112.1
     ports:
       - 8000:8000
     environment:

--- a/hack/lakefs-s3-local.yml
+++ b/hack/lakefs-s3-local.yml
@@ -16,7 +16,7 @@ services:
       restart: always
 
   lakefs:
-    image: treeverse/lakefs:0.110.0
+    image: treeverse/lakefs:0.112.1
     ports:
       - 8000:8000
     network_mode: host

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,27 +8,27 @@ build==1.0.3
     # via lakefs-spec (pyproject.toml)
 cfgv==3.4.0
     # via pre-commit
-coverage[toml]==7.3.1
+coverage[toml]==7.3.2
     # via pytest-cov
 distlib==0.3.7
     # via virtualenv
 filelock==3.12.4
     # via virtualenv
-fsspec==2023.9.1
+fsspec==2023.9.2
     # via lakefs-spec (pyproject.toml)
-identify==2.5.29
+identify==2.5.30
     # via pre-commit
 iniconfig==2.0.0
     # via pytest
-lakefs-client==0.110.0
+lakefs-client==0.112.1
     # via lakefs-spec (pyproject.toml)
 nodeenv==1.8.0
     # via pre-commit
-packaging==23.1
+packaging==23.2
     # via
     #   build
     #   pytest
-platformdirs==3.10.0
+platformdirs==3.11.0
     # via virtualenv
 pluggy==1.3.0
     # via pytest
@@ -48,7 +48,7 @@ pyyaml==6.0.1
     # via pre-commit
 six==1.16.0
     # via python-dateutil
-urllib3==2.0.5
+urllib3==2.0.6
     # via lakefs-client
 virtualenv==20.24.5
     # via pre-commit

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,13 +4,13 @@
 #
 #    pip-compile --strip-extras pyproject.toml
 #
-fsspec==2023.9.1
+fsspec==2023.9.2
     # via lakefs-spec (pyproject.toml)
-lakefs-client==0.110.0
+lakefs-client==0.112.1
     # via lakefs-spec (pyproject.toml)
 python-dateutil==2.8.2
     # via lakefs-client
 six==1.16.0
     # via python-dateutil
-urllib3==2.0.5
+urllib3==2.0.6
     # via lakefs-client

--- a/src/lakefs_spec/__init__.py
+++ b/src/lakefs_spec/__init__.py
@@ -1,5 +1,7 @@
 from importlib.metadata import PackageNotFoundError, version
 
+from lakefs_client import __version__ as __lakefs_client_version__
+
 from .spec import LakeFSFile, LakeFSFileSystem
 
 try:
@@ -7,3 +9,6 @@ try:
 except PackageNotFoundError:
     # package is not installed
     pass
+
+lakefs_client_version = tuple(int(v) for v in __lakefs_client_version__.split("."))
+del __lakefs_client_version__

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ from lakefs_client import Configuration
 from lakefs_client.client import LakeFSClient
 from lakefs_client.models import BranchCreation, RepositoryCreation
 
-from lakefs_spec import LakeFSFileSystem
+from lakefs_spec import LakeFSFileSystem, lakefs_client_version
 from tests.util import RandomFileFactory
 
 _TEST_REPO = "lakefs-spec-tests"
@@ -70,7 +70,11 @@ def ensurerepo(lakefs_client: LakeFSClient) -> str:
     if _TEST_REPO in reponames:
         logger.info(f"Test repository {_TEST_REPO!r} already exists.")
     else:
-        storage_config = lakefs_client.config_api.get_storage_config()
+        # TODO (n.junge): Remove when the required `lakefs-client` version is at least v0.111.0.
+        if lakefs_client_version < (0, 111, 0):
+            storage_config = lakefs_client.config_api.get_storage_config()
+        else:
+            storage_config = lakefs_client.config_api.get_config().storage_config
         storage_namespace = f"{storage_config.default_namespace_prefix}/{_TEST_REPO}"
         logger.info(
             f"Creating test repository {_TEST_REPO!r} "


### PR DESCRIPTION
Bumps core and dev dependencies, notably `fsspec`, `lakefs-client` and `urllib3`, the latter being a security advisory issued by dependabot on GitHub.

Bump docker compose files to use the latest stable lakeFS tag. This is currently v0.112.1, which carries some changes relevant to the Python userbase. Concretely, it seems that the `lakefs-client` package will eventually give way to the `lakefs-sdk` package.