### PR TITLE
Small fixes re: blockstore puts

### DIFF
--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -450,7 +450,7 @@ class LakeFSFileSystem(AbstractFileSystem):
         )
 
     def put_file_to_blockstore(
-        self, lpath, repository, branch, resource, presign=True, storage_options=None
+        self, lpath, repository, branch, resource, presign=False, storage_options=None
     ):
         staging_location = self.client.staging_api.get_physical_address(
             repository, branch, resource, presign=presign

--- a/tests/test_blockstore.py
+++ b/tests/test_blockstore.py
@@ -17,9 +17,8 @@ def test_local_blockstore_type(
         "lakefs_spec.spec.get_blockstore_type", new_callable=MagicMock
     ) as mock_get_client_blockstore_type:
         mock_get_client_blockstore_type.return_value = "local"
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError, match="not implemented for blockstore type 'local'"):
             fs.put_file_to_blockstore(lpath, repository, temp_branch, random_file.name)
-    assert str(exc_info.value) == "Blockstore writes not implemented for blockstore type 'local'"
 
 
 def test_presigned_url(


### PR DESCRIPTION
* Remove mutable dict default from `put_file`
* Move azure->az change to after the blockstore query to improve readability
* Move blockstore type query to the `presign=False` block to avoid the request when using presigned URLs.