### PR TITLE
Introduce future annotations and guard imports for Python 3.9 compat

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -56,8 +56,14 @@ jobs:
     - name: Run pre-commit checks
       run: |
         pre-commit run --all-files --verbose --show-diff-on-failure
-    - name: Test with pytest
+    - name: Set up oldest supported Python for testing (3.9)
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.9
+    - name: Test on oldest supported Python
       run: |
+        python -m pip install --upgrade pip pytest pytest-cov pyyaml
+        python -m pip install -e .
         pytest -s --cov=src --cov-branch
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dev = [
     "pytest>=7.4.0",
     "build>=0.10.0",
     "pytest-cov>=4.1.0",
+    "pyyaml>=6.0.1",
 ]
 
 # Register lakeFS file system via the fsspec entry point

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -45,7 +45,9 @@ pytest-cov==4.1.0
 python-dateutil==2.8.2
     # via lakefs-client
 pyyaml==6.0.1
-    # via pre-commit
+    # via
+    #   lakefs-spec (pyproject.toml)
+    #   pre-commit
 six==1.16.0
     # via python-dateutil
 urllib3==2.0.6

--- a/src/lakefs_spec/client_helpers.py
+++ b/src/lakefs_spec/client_helpers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 
 from lakefs_client.client import LakeFSClient

--- a/src/lakefs_spec/config.py
+++ b/src/lakefs_spec/config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from pathlib import Path
 from typing import Any, NamedTuple

--- a/src/lakefs_spec/errors.py
+++ b/src/lakefs_spec/errors.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import errno
 import functools
 import json

--- a/src/lakefs_spec/hooks.py
+++ b/src/lakefs_spec/hooks.py
@@ -1,4 +1,14 @@
-from enum import StrEnum, auto
+import sys
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum, auto
+else:
+    from enum import Enum, auto
+
+    class StrEnum(str, Enum):
+        pass
+
+
 from typing import Callable, NamedTuple
 
 from lakefs_client.client import LakeFSClient

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import hashlib
 import io
 import logging


### PR DESCRIPTION
We want to at least support Python 3.9, so the following had to be changed:

1. `from __future__ import annotations` to enable `X | Y` union type annotations for pre-3.10 Python versions.
2. Set `StrEnum` as a str+Enum mixin in versions prior to 3.11. This is not strictly equivalent to Python 3.11's `StrEnum`, but for our uses it behaves exactly the same.

Fixes #103.