### PR TITLE
Change lakeFS package to `lakefs-sdk` in place of `lakefs-client`

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       lakefs:
-        image: treeverse/lakefs:0.112.1
+        image: treeverse/lakefs:1.0.0
         ports:
           - 8000:8000
         env:

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ file system's lakeFS API client, and the `context` object contains information a
 As an example, the following snippet installs a lakeFS hook that creates a commit on the lakeFS branch after a file upload:
 
 ```python
-from lakefs_client.client import LakeFSClient
+from lakefs_sdk.client import LakeFSClient
 
 from lakefs_spec import LakeFSFileSystem
 from lakefs_spec.client_helpers import commit

--- a/demos/rain_prediction.ipynb
+++ b/demos/rain_prediction.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -9,6 +10,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -23,6 +25,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -40,6 +43,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -56,6 +60,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -77,6 +82,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -96,6 +102,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -125,6 +132,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -133,6 +141,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -146,7 +155,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from lakefs_client.client import LakeFSClient\n",
+    "from lakefs_sdk.client import LakeFSClient\n",
     "from lakefs_spec.client_helpers import commit\n",
     "from lakefs_spec.hooks import FSEvent, HookContext\n",
     "\n",
@@ -163,6 +172,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -181,6 +191,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -188,6 +199,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -224,6 +236,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -240,6 +253,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -261,6 +275,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -279,6 +294,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -286,6 +302,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -305,6 +322,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -333,6 +351,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -353,6 +372,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -382,6 +402,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -416,6 +437,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -438,6 +460,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -457,6 +480,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -477,6 +501,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -488,6 +513,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": []

--- a/demos/rain_prediction.ipynb
+++ b/demos/rain_prediction.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -10,7 +9,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -25,7 +23,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -43,7 +40,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -60,7 +56,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -82,7 +77,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -102,7 +96,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -132,7 +125,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -141,7 +133,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -172,7 +163,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -191,7 +181,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -199,7 +188,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -236,7 +224,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -253,7 +240,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -275,7 +261,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -294,7 +279,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -302,7 +286,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -322,7 +305,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -351,7 +333,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -372,7 +353,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -402,7 +382,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -437,7 +416,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -460,7 +438,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -480,7 +457,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -501,7 +477,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -513,7 +488,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": []

--- a/demos/requirements.txt
+++ b/demos/requirements.txt
@@ -12,8 +12,8 @@ jedi==0.19.0
 joblib==1.3.2
 jupyter_client==8.3.1
 jupyter_core==5.3.1
-lakefs-client==0.113.0.1
-lakefs-spec @ git+https://github.com/appliedAI-Initiative/lakefs-spec.git@8bd2477dbb466f85c714a8659bb66cd92c53cbc7
+lakefs-sdk==1.0.0
+lakefs-spec @ git+https://github.com/appliedAI-Initiative/lakefs-spec.git@main
 matplotlib-inline==0.1.6
 nest-asyncio==1.5.7
 numpy==1.25.2

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -9,8 +9,8 @@ and (mostly) works as advertised, it has its issues - the developer experience b
 typing information, and the woes of reading lots of raw client code, for example when downloading a file to load into a data frame:
 
 ```python
-from lakefs_client import Configuration
-from lakefs_client.client import LakeFSClient
+from lakefs_sdk import Configuration
+from lakefs_sdk.client import LakeFSClient
 
 # painful!
 configuration = Configuration(host="my-host")
@@ -85,7 +85,7 @@ A concrete example of this is creating lakeFS commits after a successful file up
 Commits provide a snapshot of a lakeFS repository, similarly to version control systems like git.
 
 ```python
-from lakefs_client.client import LakeFSClient
+from lakefs_sdk.client import LakeFSClient
 
 from lakefs_spec import LakeFSFileSystem
 from lakefs_spec.client_helpers import commit

--- a/hack/docker-compose.yml
+++ b/hack/docker-compose.yml
@@ -4,7 +4,7 @@ version: "3"
 
 services:
   lakefs:
-    image: treeverse/lakefs:0.112.1
+    image: treeverse/lakefs:1.0.0
     ports:
       - 8000:8000
     environment:

--- a/hack/lakefs-s3-local.yml
+++ b/hack/lakefs-s3-local.yml
@@ -13,7 +13,7 @@ services:
       - ./config/s3.json:/etc/seaweedfs/s3.json
 
   lakefs:
-    image: treeverse/lakefs:0.112.1
+    image: treeverse/lakefs:1.0.0
     network_mode: host
     depends_on:
       - seaweedfs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 
-dependencies = ["fsspec>=2023.6.0", "lakefs-client>=0.105.0"]
+dependencies = ["fsspec>=2023.6.0", "lakefs-sdk>=0.113.0.2"]
 
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 
-dependencies = ["fsspec>=2023.6.0", "lakefs-sdk>=0.113.0.2"]
+dependencies = ["fsspec>=2023.6.0", "lakefs-sdk>=1.0.0"]
 
 dynamic = ["version"]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,9 +11,7 @@ build==1.0.3
 cfgv==3.4.0
     # via pre-commit
 coverage[toml]==7.3.2
-    # via
-    #   coverage
-    #   pytest-cov
+    # via pytest-cov
 distlib==0.3.7
     # via virtualenv
 filelock==3.12.4
@@ -56,9 +54,7 @@ pyyaml==6.0.1
     #   lakefs-spec (pyproject.toml)
     #   pre-commit
 setuptools-scm[toml]==8.0.4
-    # via
-    #   lakefs-spec (pyproject.toml)
-    #   setuptools-scm
+    # via lakefs-spec (pyproject.toml)
 six==1.16.0
     # via python-dateutil
 typing-extensions==4.8.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,23 +4,27 @@
 #
 #    pip-compile --extra=dev --output-file=requirements-dev.txt pyproject.toml
 #
+aenum==3.1.15
+    # via lakefs-sdk
 build==1.0.3
     # via lakefs-spec (pyproject.toml)
 cfgv==3.4.0
     # via pre-commit
 coverage[toml]==7.3.2
-    # via pytest-cov
+    # via
+    #   coverage
+    #   pytest-cov
 distlib==0.3.7
     # via virtualenv
 filelock==3.12.4
     # via virtualenv
-fsspec==2023.9.2
+fsspec==2023.10.0
     # via lakefs-spec (pyproject.toml)
 identify==2.5.30
     # via pre-commit
 iniconfig==2.0.0
     # via pytest
-lakefs-client==1.0.0
+lakefs-sdk==1.0.0
     # via lakefs-spec (pyproject.toml)
 nodeenv==1.8.0
     # via pre-commit
@@ -35,6 +39,8 @@ pluggy==1.3.0
     # via pytest
 pre-commit==3.5.0
     # via lakefs-spec (pyproject.toml)
+pydantic==1.10.13
+    # via lakefs-sdk
 pyproject-hooks==1.0.0
     # via build
 pytest==7.4.2
@@ -44,20 +50,24 @@ pytest==7.4.2
 pytest-cov==4.1.0
     # via lakefs-spec (pyproject.toml)
 python-dateutil==2.8.2
-    # via lakefs-client
+    # via lakefs-sdk
 pyyaml==6.0.1
     # via
     #   lakefs-spec (pyproject.toml)
     #   pre-commit
 setuptools-scm[toml]==8.0.4
-    # via lakefs-spec (pyproject.toml)
+    # via
+    #   lakefs-spec (pyproject.toml)
+    #   setuptools-scm
 six==1.16.0
     # via python-dateutil
 typing-extensions==4.8.0
-    # via setuptools-scm
+    # via
+    #   pydantic
+    #   setuptools-scm
 urllib3==2.0.7
-    # via lakefs-client
-virtualenv==20.24.5
+    # via lakefs-sdk
+virtualenv==20.24.6
     # via pre-commit
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,7 +11,9 @@ build==1.0.3
 cfgv==3.4.0
     # via pre-commit
 coverage[toml]==7.3.2
-    # via pytest-cov
+    # via
+    #   coverage
+    #   pytest-cov
 distlib==0.3.7
     # via virtualenv
 filelock==3.12.4
@@ -54,7 +56,9 @@ pyyaml==6.0.1
     #   lakefs-spec (pyproject.toml)
     #   pre-commit
 setuptools-scm[toml]==8.0.4
-    # via lakefs-spec (pyproject.toml)
+    # via
+    #   lakefs-spec (pyproject.toml)
+    #   setuptools-scm
 six==1.16.0
     # via python-dateutil
 typing-extensions==4.8.0

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -31,7 +31,7 @@ backcall==0.2.0
     # via ipython
 beautifulsoup4==4.12.2
     # via nbconvert
-black==23.10.0
+black==23.10.1
     # via lakefs-spec (pyproject.toml)
 bleach==6.1.0
     # via nbconvert
@@ -39,7 +39,7 @@ certifi==2023.7.22
     # via requests
 cffi==1.16.0
     # via argon2-cffi-bindings
-charset-normalizer==3.3.0
+charset-normalizer==3.3.1
     # via requests
 click==8.1.7
     # via
@@ -65,11 +65,11 @@ fastjsonschema==2.18.1
     # via nbformat
 fqdn==1.5.1
     # via jsonschema
-fsspec==2023.9.2
+fsspec==2023.10.0
     # via lakefs-spec (pyproject.toml)
 ghp-import==2.1.0
     # via mkdocs
-gitdb==4.0.10
+gitdb==4.0.11
     # via gitpython
 gitpython==3.1.40
     # via
@@ -342,7 +342,7 @@ pyzmq==25.1.1
     #   qtconsole
 qtconsole==5.4.4
     # via jupyter
-qtpy==2.4.0
+qtpy==2.4.1
     # via qtconsole
 referencing==0.30.2
     # via

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -4,6 +4,8 @@
 #
 #    pip-compile --extra=docs --output-file=requirements-docs.txt pyproject.toml
 #
+aenum==3.1.15
+    # via lakefs-sdk
 anyio==4.0.0
     # via jupyter-server
 argon2-cffi==23.1.0
@@ -166,7 +168,7 @@ jupyterlab-server==2.25.0
     #   notebook
 jupyterlab-widgets==3.0.9
     # via ipywidgets
-lakefs-client==1.0.0
+lakefs-sdk==1.0.0
     # via lakefs-spec (pyproject.toml)
 markdown==3.5
     # via
@@ -299,6 +301,8 @@ pure-eval==0.2.2
     # via stack-data
 pycparser==2.21
     # via cffi
+pydantic==1.10.13
+    # via lakefs-sdk
 pygments==2.16.1
     # via
     #   ipython
@@ -315,7 +319,7 @@ python-dateutil==2.8.2
     #   arrow
     #   ghp-import
     #   jupyter-client
-    #   lakefs-client
+    #   lakefs-sdk
 python-json-logger==2.0.7
     # via jupyter-events
 pytz==2023.3.post1
@@ -412,11 +416,13 @@ traitlets==5.11.2
     #   qtconsole
 types-python-dateutil==2.8.19.14
     # via arrow
+typing-extensions==4.8.0
+    # via pydantic
 uri-template==1.3.0
     # via jsonschema
 urllib3==2.0.7
     # via
-    #   lakefs-client
+    #   lakefs-sdk
     #   requests
 verspec==0.1.0
     # via mike

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,13 +4,19 @@
 #
 #    pip-compile --strip-extras pyproject.toml
 #
-fsspec==2023.9.2
+aenum==3.1.15
+    # via lakefs-sdk
+fsspec==2023.10.0
     # via lakefs-spec (pyproject.toml)
-lakefs-client==1.0.0
+lakefs-sdk==1.0.0
     # via lakefs-spec (pyproject.toml)
+pydantic==1.10.13
+    # via lakefs-sdk
 python-dateutil==2.8.2
-    # via lakefs-client
+    # via lakefs-sdk
 six==1.16.0
     # via python-dateutil
+typing-extensions==4.8.0
+    # via pydantic
 urllib3==2.0.7
-    # via lakefs-client
+    # via lakefs-sdk

--- a/src/lakefs_spec/__init__.py
+++ b/src/lakefs_spec/__init__.py
@@ -2,7 +2,7 @@
 
 from importlib.metadata import PackageNotFoundError, version
 
-from lakefs_client import __version__ as __lakefs_client_version__
+from lakefs_sdk import __version__ as __lakefs_sdk_version__
 
 from .spec import LakeFSFile, LakeFSFileSystem
 
@@ -12,5 +12,5 @@ except PackageNotFoundError:
     # package is not installed
     pass
 
-lakefs_client_version = tuple(int(v) for v in __lakefs_client_version__.split("."))
-del __lakefs_client_version__
+lakefs_sdk_version = tuple(int(v) for v in __lakefs_sdk_version__.split("."))
+del __lakefs_sdk_version__

--- a/src/lakefs_spec/client_helpers.py
+++ b/src/lakefs_spec/client_helpers.py
@@ -29,7 +29,7 @@ def commit(
 
 
 def create_tag(client: LakeFSClient, repository: str, ref: str, tag: str) -> None:
-    tag_creation = TagCreation(tag, ref=ref)
+    tag_creation = TagCreation(id=tag, ref=ref)
     client.tags_api.create_tag(repository=repository, tag_creation=tag_creation)
 
 

--- a/src/lakefs_spec/client_helpers.py
+++ b/src/lakefs_spec/client_helpers.py
@@ -2,11 +2,9 @@ from __future__ import annotations
 
 import logging
 
-from lakefs_client.client import LakeFSClient
-from lakefs_client.exceptions import NotFoundException
-from lakefs_client.model.commit_creation import CommitCreation
-from lakefs_client.model.revert_creation import RevertCreation
-from lakefs_client.model.tag_creation import TagCreation
+from lakefs_sdk.client import LakeFSClient
+from lakefs_sdk.exceptions import NotFoundException
+from lakefs_sdk.models import CommitCreation, RevertCreation, TagCreation
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)

--- a/src/lakefs_spec/errors.py
+++ b/src/lakefs_spec/errors.py
@@ -4,7 +4,7 @@ import errno
 import functools
 import json
 
-from lakefs_client import ApiException
+from lakefs_sdk import ApiException
 
 HTTP_CODE_TO_ERROR: dict[int, type[OSError]] = {
     401: PermissionError,

--- a/src/lakefs_spec/hooks.py
+++ b/src/lakefs_spec/hooks.py
@@ -11,7 +11,7 @@ else:
 
 from typing import Callable, NamedTuple
 
-from lakefs_client.client import LakeFSClient
+from lakefs_sdk.client import LakeFSClient
 
 from lakefs_spec.util import parse
 

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -17,11 +17,10 @@ from fsspec import filesystem
 from fsspec.callbacks import NoOpCallback
 from fsspec.spec import AbstractBufferedFile, AbstractFileSystem
 from fsspec.utils import isfilelike, stringify_path
-from lakefs_client import Configuration
-from lakefs_client.client import LakeFSClient
-from lakefs_client.exceptions import ApiException, NotFoundException
-from lakefs_client.model.staging_metadata import StagingMetadata
-from lakefs_client.models import BranchCreation, ObjectCopyCreation, ObjectStatsList
+from lakefs_sdk import Configuration
+from lakefs_sdk.client import LakeFSClient
+from lakefs_sdk.exceptions import ApiException, NotFoundException
+from lakefs_sdk.models import BranchCreation, ObjectCopyCreation, ObjectStatsList, StagingMetadata
 
 from lakefs_spec.config import LakectlConfig
 from lakefs_spec.errors import translate_lakefs_error

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import hashlib
-import io
 import logging
 import mimetypes
 import operator
@@ -300,9 +299,11 @@ class LakeFSFileSystem(AbstractFileSystem):
             ctx = HookContext(repository=repository, ref=ref, resource=resource)
             self.run_hook(FSEvent.GET_FILE, ctx)
 
+        info = self.info(rpath)
+
         if precheck and Path(lpath).exists():
             local_checksum = md5_checksum(lpath, blocksize=self.blocksize)
-            remote_checksum = self.checksum(rpath)
+            remote_checksum = info.get("checksum")
             if local_checksum == remote_checksum:
                 logger.info(
                     f"Skipping download of resource {rpath!r} to local path {lpath!r}: "
@@ -317,14 +318,19 @@ class LakeFSFileSystem(AbstractFileSystem):
             outfile = open(lpath, "wb")
 
         try:
-            res: io.BufferedReader = self.client.objects_api.get_object(
-                repository, ref, resource, **kwargs
-            )
+            offset, filesize = 0, info.get("size")
             while True:
-                chunk = res.read(self.blocksize)
-                if not chunk:
-                    break
+                next_offset = max(offset + self.blocksize, filesize)
+                byterange = f"bytes={offset}-{next_offset - 1}"
+
+                chunk = self.client.objects_api.get_object(
+                    repository, ref, resource, range=byterange, **kwargs
+                )
                 outfile.write(chunk)
+
+                offset += self.blocksize
+                if next_offset >= filesize:
+                    break
         except ApiException as e:
             from fsspec.implementations.local import LocalFileSystem
 
@@ -545,11 +551,10 @@ class LakeFSFileSystem(AbstractFileSystem):
                 storage_options=storage_options,
             )
         else:
-            with open(lpath, "rb") as f:
-                with self.wrapped_api_call():
-                    self.client.objects_api.upload_object(
-                        repository=repository, branch=branch, path=resource, content=f, **kwargs
-                    )
+            with self.wrapped_api_call():
+                self.client.objects_api.upload_object(
+                    repository=repository, branch=branch, path=resource, content=lpath, **kwargs
+                )
 
         run_put_file_hook()
 
@@ -639,11 +644,11 @@ class LakeFSFile(AbstractBufferedFile):
                 # single-shot upload.
                 # empty buffer is equivalent to a touch()
                 self.buffer.seek(0)
-                self.fs.client.objects.upload_object(
+                self.fs.client.objects_api.upload_object(
                     repository=repository,
                     branch=branch,
                     path=resource,
-                    content=self.buffer,
+                    content=self.buffer.read(),
                 )
 
         return not final
@@ -693,10 +698,9 @@ class LakeFSFile(AbstractBufferedFile):
     def _fetch_range(self, start: int, end: int) -> bytes:
         repository, ref, resource = parse(self.path)
         with self.fs.wrapped_api_call():
-            res: io.BufferedReader = self.fs.client.objects.get_object(
+            return self.fs.client.objects_api.get_object(
                 repository, ref, resource, range=f"bytes={start}-{end - 1}"
             )
-            return res.read()
 
     def close(self):
         super().close()

--- a/src/lakefs_spec/util.py
+++ b/src/lakefs_spec/util.py
@@ -1,7 +1,7 @@
 import re
 
-from lakefs_client import __version__ as __lakefs_client_version__
-from lakefs_client.client import LakeFSClient
+from lakefs_sdk import __version__ as __lakefs_sdk_version__
+from lakefs_sdk.client import LakeFSClient
 
 
 def parse(path: str) -> tuple[str, str, str]:
@@ -35,8 +35,8 @@ def parse(path: str) -> tuple[str, str, str]:
     return repo, ref, resource
 
 
-lakefs_client_version = tuple(int(v) for v in __lakefs_client_version__.split("."))
-del __lakefs_client_version__
+lakefs_client_version = tuple(int(v) for v in __lakefs_sdk_version__.split("."))
+del __lakefs_sdk_version__
 
 
 def get_blockstore_type(client: LakeFSClient) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,9 +10,9 @@ from unittest.mock import MagicMock
 
 import pytest
 import yaml
-from lakefs_client import Configuration
-from lakefs_client.client import LakeFSClient
-from lakefs_client.models import BranchCreation, RepositoryCreation
+from lakefs_sdk import Configuration
+from lakefs_sdk.client import LakeFSClient
+from lakefs_sdk.models import BranchCreation, RepositoryCreation
 
 from lakefs_spec import LakeFSFileSystem
 from lakefs_spec.util import lakefs_client_version

--- a/tests/test_blockstore.py
+++ b/tests/test_blockstore.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
-from lakefs_client.model.staging_location import StagingLocation
+from lakefs_sdk.models.staging_location import StagingLocation
 
 from lakefs_spec import LakeFSFileSystem
 from tests.util import RandomFileFactory

--- a/tests/test_client_helpers.py
+++ b/tests/test_client_helpers.py
@@ -18,18 +18,14 @@ def test_create_tag(
     client_helpers.commit(
         client=fs.client, repository=repository, branch=temp_branch, message="Commit File Factory"
     )
-    try:
-        tag_name = f"Change_{uuid.uuid4()}"
-        client_helpers.create_tag(
-            client=fs.client, repository=repository, ref=temp_branch, tag=tag_name
-        )
 
-        assert any(
-            commit.get("id") == tag_name
-            for commit in fs.client.tags_api.list_tags(repository).results
-        )
+    tag = f"Change_{uuid.uuid4()}"
+    try:
+        client_helpers.create_tag(client=fs.client, repository=repository, ref=temp_branch, tag=tag)
+
+        assert any(commit.id == tag for commit in fs.client.tags_api.list_tags(repository).results)
     finally:
-        fs.client.tags_api.delete_tag(repository=repository, tag=tag_name)
+        fs.client.tags_api.delete_tag(repository=repository, tag=tag)
 
 
 def test_merge_into_branch(

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,5 +1,5 @@
 import pytest
-from lakefs_client.client import LakeFSClient
+from lakefs_sdk.client import LakeFSClient
 
 from lakefs_spec import LakeFSFileSystem
 from lakefs_spec.hooks import FSEvent, HookContext

--- a/tests/test_lakefs_file.py
+++ b/tests/test_lakefs_file.py
@@ -47,7 +47,11 @@ def test_lakefs_file_open_write(
 
     # pulling the written file down again, using ONLY built-in open (!)
     lpath = random_file.with_name(random_file.name + "_copy")
+
+    blocksize = fs.blocksize
+    fs.blocksize = 256
     fs.get(rpath, str(lpath))
+    fs.blocksize = blocksize
 
     with open(lpath, "rb") as f:
         new_text = f.read()

--- a/tests/test_put_file.py
+++ b/tests/test_put_file.py
@@ -2,7 +2,7 @@ import random
 import string
 
 import pytest
-from lakefs_client.client import LakeFSClient
+from lakefs_sdk.client import LakeFSClient
 
 from lakefs_spec import LakeFSFileSystem
 from lakefs_spec.client_helpers import commit

--- a/tests/test_rm.py
+++ b/tests/test_rm.py
@@ -1,4 +1,4 @@
-from lakefs_client.client import LakeFSClient
+from lakefs_sdk.client import LakeFSClient
 
 from lakefs_spec import LakeFSFileSystem
 from lakefs_spec.client_helpers import commit

--- a/tests/util.py
+++ b/tests/util.py
@@ -6,7 +6,7 @@ from inspect import ismethod
 from pathlib import Path
 from typing import Optional, Union
 
-from lakefs_client.client import LakeFSClient
+from lakefs_sdk.client import LakeFSClient
 
 
 class APICounter:


### PR DESCRIPTION
In preparation for the lakeFS v1 launch, change the package to depend on their newly launched `lakefs-sdk` to keep up to date with their upstream changes.

The import change is largely a name replacement only, with the exception of the model imports now happening from the `lakefs_sdk.models` subpackage.