### PR TITLE
Add README on hack/ folder resources

### DIFF
--- a/hack/README.md
+++ b/hack/README.md
@@ -16,16 +16,12 @@ To bootstrap, run the following command:
 docker compose -f hack/docker-compose.yml up
 ```
 
-To stop the container again, run
-
-```shell
-docker compose -f hack/docker-compose.yml down
-```
+To stop the container again, exit with `Ctrl-c`.
 
 ## `lakefs-s3-local.yml` - lakeFS with a local, SeaweedFS-backed S3 blockstore
 
 For simulating a lakeFS deployment with a remote blockstore, the `lakefs-s3-local.yml` Docker Compose file contains a
-recipe mocking an S3 blockstore using SeaweedFS.
+recipe with a local S3 blockstore implementation using [SeaweedFS](https://github.com/seaweedfs/seaweedfs/wiki).
 
 To bootstrap this setup, run the command
 
@@ -33,7 +29,7 @@ To bootstrap this setup, run the command
 docker compose -f hack/lakefs-s3-local.yml up
 ```
 
-To stop the containers again, run
+To stop the containers again, exit with `Ctrl-C`.
 
 ```shell
 docker compose -f hack/lakefs-s3-local.yml down
@@ -43,11 +39,8 @@ To clean the created volume, e.g. for when you want to remove created storage na
 you can nuke the deployment like so:
 
 ```shell
-docker compose -f hack/lakefs-s3-local.yml rm
-docker volume rm hack_seaweedfs-data
+docker compose -f hack/lakefs-s3-local.yml rm -v
 ```
-
-## Mock credentials for direct blockstore writes with the `LakeFSFileSystem`
 
 In order to write to the local S3 blockstore using `LakeFSFileSystem.put_file_to_blockstore`, you can use the following
 mock credentials:

--- a/hack/README.md
+++ b/hack/README.md
@@ -31,8 +31,8 @@ docker compose -f hack/lakefs-s3-local.yml up
 
 To stop the containers again, exit with `Ctrl-C`.
 
-To clean the created volume, e.g. for when you want to remove created storage namespaces after repository deletions,
-you can nuke the deployment like so:
+To clean the created volume, e.g., for when you want to remove created storage namespaces after repository deletions,
+you can remove the container and attached volume like so:
 
 ```shell
 docker compose -f hack/lakefs-s3-local.yml rm -v

--- a/hack/README.md
+++ b/hack/README.md
@@ -1,0 +1,64 @@
+# Useful resources for development on `lakefs-spec`
+
+This document contains information on the resources in this directory, and how they can be used in development and testing.
+
+## `docker-compose.yml` - local lakeFS quickstart instance
+
+This Docker Compose file bootstraps a local [lakeFS quickstart instance](https://docs.lakefs.io/quickstart/launch.html).
+It does not come with an associated volume, so you can spin it up and down without creating dangling resources.
+
+Requirements:
+* A Docker runtime & CLI with `docker compose`.
+
+To bootstrap, run the following command:
+
+```shell
+docker compose -f hack/docker-compose.yml up
+```
+
+To stop the container again, run
+
+```shell
+docker compose -f hack/docker-compose.yml down
+```
+
+## `lakefs-s3-local.yml` - lakeFS with a local, SeaweedFS-backed S3 blockstore
+
+For simulating a lakeFS deployment with a remote blockstore, the `lakefs-s3-local.yml` Docker Compose file contains a
+recipe mocking an S3 blockstore using SeaweedFS.
+
+To bootstrap this setup, run the command
+
+```shell
+docker compose -f hack/lakefs-s3-local.yml up
+```
+
+To stop the containers again, run
+
+```shell
+docker compose -f hack/lakefs-s3-local.yml down
+```
+
+To clean the created volume, e.g. for when you want to remove created storage namespaces after repository deletions,
+you can nuke the deployment like so:
+
+```shell
+docker compose -f hack/lakefs-s3-local.yml rm
+docker volume rm hack_seaweedfs-data
+```
+
+## Mock credentials for direct blockstore writes with the `LakeFSFileSystem`
+
+In order to write to the local S3 blockstore using `LakeFSFileSystem.put_file_to_blockstore`, you can use the following
+mock credentials:
+
+```shell
+cat > $HOME/.aws/credentials <<EOL
+[default]
+endpoint_url = http://localhost:9001
+aws_access_key_id = sandbox
+aws_secret_access_key = sandbox
+EOL
+```
+
+Beware that this will overwrite any existing credential files, so it is recommended to back those up first.

--- a/hack/README.md
+++ b/hack/README.md
@@ -39,7 +39,25 @@ docker compose -f hack/lakefs-s3-local.yml rm -v
 ```
 
 In order to write to the local S3 blockstore using `LakeFSFileSystem.put_file_to_blockstore`, you can use the following
-mock credentials:
+environment variables and values:
+
+```shell
+export AWS_ENDPOINT_URL="http://localhost:9001"
+export AWS_ACCESS_KEY_ID=sandbox
+export AWS_SECRET_ACCESS_KEY=sandbox
+```
+
+or, in Python directly,
+
+```python
+import os
+
+os.environ["AWS_ENDPOINT_URL"] = "http://localhost:9001"
+os.environ["AWS_ACCESS_KEY_ID"] = "sandbox"
+os.environ["AWS_SECRET_ACCESS_KEY"] = "sandbox"
+```
+
+If you prefer working with AWS credential files, you can run the following setup command:
 
 ```shell
 cat > $HOME/.aws/credentials <<EOL
@@ -47,7 +65,6 @@ cat > $HOME/.aws/credentials <<EOL
 endpoint_url = http://localhost:9001
 aws_access_key_id = sandbox
 aws_secret_access_key = sandbox
-EOL
 ```
 
-Beware that this will overwrite any existing credential files, so it is recommended to back those up first.
+Beware that this will overwrite an existing AWS credential file, so it is recommended to back it up first.

--- a/hack/README.md
+++ b/hack/README.md
@@ -31,10 +31,6 @@ docker compose -f hack/lakefs-s3-local.yml up
 
 To stop the containers again, exit with `Ctrl-C`.
 
-```shell
-docker compose -f hack/lakefs-s3-local.yml down
-```
-
 To clean the created volume, e.g. for when you want to remove created storage namespaces after repository deletions,
 you can nuke the deployment like so:
 


### PR DESCRIPTION
Contains a few short explanatory sentences and instructions on the various deployments and when/how to use them, including cleanup for the S3 volume.

Also contains a mock credential file for running zero-config integration tests on blockstore puts (with `LakeFSFileSystem.put_file_to_blockstore`) in the case of S3 via SeaweedFS.

Let's see if dependabot starts screaming because of the credentials.

Closes #94.