### PR TITLE
Run `pre-commit autoupdate`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,14 +16,14 @@ repos:
       - id: end-of-file-fixer
       - id: mixed-line-ending
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.5.1
+    rev: v1.6.1
     hooks:
       # See https://github.com/pre-commit/mirrors-mypy/blob/main/.pre-commit-hooks.yaml
      - id: mypy
        types_or: [ python, pyi ]
        args: ["--ignore-missing-imports", "--scripts-are-modules"]
   - repo: https://github.com/psf/black
-    rev: 23.9.1
+    rev: 23.10.1
     hooks:
       - id: black
   - repo: https://github.com/pycqa/isort
@@ -31,7 +31,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.292
+    rev: v0.1.2
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix ]


### PR DESCRIPTION
Bumps the following tools:
* mypy  v1.5.1 -> v1.6.1
* black v23.9.1 -> v23.10.1
* ruff  v0.0.292 -> v0.1.2

In particular, this brings ruff to the first "stable" v0.1.x.