### PR TITLE
Add type hints to lakeFS file and file system [ENG-123]

### DIFF
--- a/src/lakefs_spec/errors.py
+++ b/src/lakefs_spec/errors.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import errno
 import functools
 import json
+from typing import Any
 
 from lakefs_sdk import ApiException
 
@@ -13,8 +14,11 @@ HTTP_CODE_TO_ERROR: dict[int, type[OSError]] = {
 }
 
 
-def translate_lakefs_error(  # type: ignore
-    error: ApiException, message: str | None = None, set_cause: bool = True, *args
+def translate_lakefs_error(
+    error: ApiException,
+    message: str | None = None,
+    set_cause: bool = True,
+    *args: Any,
 ) -> OSError:
     """Convert a lakeFS client ApiException into a Python exception.
 

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -32,7 +32,6 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 EmptyYield = Generator[None, None, None]
-FileSystemPath = str | os.PathLike[str] | Path
 
 _warn_on_fileupload = True
 
@@ -179,25 +178,23 @@ class LakeFSFileSystem(AbstractFileSystem):
 
     @classmethod
     @overload
-    def _strip_protocol(cls, path: FileSystemPath) -> str:
+    def _strip_protocol(cls, path: str | os.PathLike[str] | Path) -> str:
         ...
 
     @classmethod
     @overload
-    def _strip_protocol(cls, path: list[FileSystemPath]) -> list[str]:
+    def _strip_protocol(cls, path: list[str | os.PathLike[str] | Path]) -> list[str]:
         ...
 
     @classmethod
     def _strip_protocol(cls, path):
         """Copied verbatim from the base class, save for the slash rstrip."""
         if isinstance(path, list):
-            paths: list[str] = [cls._strip_protocol(p) for p in path]
-            return paths
-        else:
-            spath: str = super()._strip_protocol(path)
-            if stringify_path(path).endswith("/"):
-                return spath + "/"
-            return spath
+            return [cls._strip_protocol(p) for p in path]
+        spath = super()._strip_protocol(path)
+        if stringify_path(path).endswith("/"):
+            return spath + "/"
+        return spath
 
     @contextmanager
     def wrapped_api_call(self, message: str | None = None, set_cause: bool = True) -> EmptyYield:


### PR DESCRIPTION
These type hints are the strictest they can be without excessive errors.

This leads to a few relaxations, though:

* The `outfile` argument was reduced to `typing.Any`, since it is optionally assigned to a str or IO class, which is hard to capture and model correctly.
* Paths are currently limited to `str`s, since they are fed directly to the lakeFS URI regex parser.

Followup PRs could e.g. add support for `PathLike`s as {r,l}paths.