### PR TITLE
Remove stale lakeFS SDK branch statement

### DIFF
--- a/src/lakefs_spec/__init__.py
+++ b/src/lakefs_spec/__init__.py
@@ -2,8 +2,6 @@
 
 from importlib.metadata import PackageNotFoundError, version
 
-from lakefs_sdk import __version__ as __lakefs_sdk_version__
-
 from .spec import LakeFSFile, LakeFSFileSystem
 
 try:
@@ -11,6 +9,3 @@ try:
 except PackageNotFoundError:
     # package is not installed
     pass
-
-lakefs_sdk_version = tuple(int(v) for v in __lakefs_sdk_version__.split("."))
-del __lakefs_sdk_version__

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -24,7 +24,7 @@ from lakefs_sdk.models import BranchCreation, ObjectCopyCreation, ObjectStatsLis
 from lakefs_spec.config import LakectlConfig
 from lakefs_spec.errors import translate_lakefs_error
 from lakefs_spec.hooks import FSEvent, HookContext, LakeFSHook, noop
-from lakefs_spec.util import get_blockstore_type, parse
+from lakefs_spec.util import parse
 
 _DEFAULT_CALLBACK = NoOpCallback()
 
@@ -508,7 +508,7 @@ class LakeFSFileSystem(AbstractFileSystem):
                     )
                     translate_lakefs_error(error=urllib_http_error_as_lakefs_api_exception)
         else:
-            blockstore_type = get_blockstore_type(self.client)
+            blockstore_type = self.client.config_api.get_config().storage_config.blockstore_type
             # lakeFS blockstore name is "azure", but Azure's fsspec registry entry is "az".
             if blockstore_type == "azure":
                 blockstore_type = "az"

--- a/src/lakefs_spec/util.py
+++ b/src/lakefs_spec/util.py
@@ -1,7 +1,9 @@
 import re
 
 from lakefs_sdk import __version__ as __lakefs_sdk_version__
-from lakefs_sdk.client import LakeFSClient
+
+lakefs_sdk_version = tuple(int(v) for v in __lakefs_sdk_version__.split("."))
+del __lakefs_sdk_version__
 
 
 def parse(path: str) -> tuple[str, str, str]:
@@ -33,25 +35,3 @@ def parse(path: str) -> tuple[str, str, str]:
 
     repo, ref, resource = results.groups()
     return repo, ref, resource
-
-
-lakefs_client_version = tuple(int(v) for v in __lakefs_sdk_version__.split("."))
-del __lakefs_sdk_version__
-
-
-def get_blockstore_type(client: LakeFSClient) -> str:
-    """
-    Get the blockstore of the lakeFS server.
-    Backwards compatible to breaking config_api change in lakeFSClient version 0.110.1.
-
-    Args:
-        client (LakeFSClient): The lakefs client.
-
-    Returns:
-        str: The lakeFS server's blockstore type.
-    """
-    if lakefs_client_version < (0, 111, 0):
-        blockstore_type = client.config_api.get_storage_config().blockstore_type
-    else:
-        blockstore_type = client.config_api.get_config().storage_config.blockstore_type
-    return blockstore_type


### PR DESCRIPTION
Since we require `lakefs-sdk>=1.0.0` in the `pyproject.toml`, we can drop the SDK/client version guard.