### PR TITLE
Minor test cleanups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,3 +119,7 @@ ignore = [
 
 [tool.bandit]
 exclude_dirs = ["tests"]
+
+[tool.pytest.ini_options]
+log_cli = true
+log_cli_level = "WARNING"

--- a/tests/test_put_file.py
+++ b/tests/test_put_file.py
@@ -118,9 +118,9 @@ def test_put_client_caching(
     lpath = str(random_file)
     rpath = f"{repository}/{temp_branch}/{random_file.name}"
     fs.put(lpath, rpath)
+    assert counter.count("objects_api.upload_object") == 1
     assert fs.exists(rpath)
 
     # second put, should not happen.
     fs.put(lpath, rpath)
-    print(list(counter.named_counts()))
     assert counter.count("objects_api.upload_object") == 1

--- a/tests/util.py
+++ b/tests/util.py
@@ -49,7 +49,10 @@ def with_counter(client: LakeFSClient) -> tuple[LakeFSClient, APICounter]:
             continue
 
         for ep_name in filter(
-            lambda op: not op.startswith("_") and ismethod(getattr(api, op)), dir(api)
+            lambda op: not op.startswith("_")
+            and not op.endswith("with_http_info")
+            and ismethod(getattr(api, op)),
+            dir(api),
         ):
             endpoint = getattr(api, ep_name)
             setattr(api, ep_name, patch(endpoint, f"{api_name}.{ep_name}"))


### PR DESCRIPTION
Includes removing a debug print statement that got checked in, and tightening the API counter instrumentation check to not include the `call_api_with_http_info` methods (they showed up in GitHub actions test logs).