### PR TITLE
Explicitly check for existence in `LakectlConfig.read()`

### DIFF
--- a/src/lakefs_spec/config.py
+++ b/src/lakefs_spec/config.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
-import logging
+import warnings
 from pathlib import Path
 from typing import Any, NamedTuple
-
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 
 class LakectlConfig(NamedTuple):
@@ -21,9 +18,10 @@ class LakectlConfig(NamedTuple):
         try:
             import yaml
         except ModuleNotFoundError:
-            logger.warning(
+            warnings.warn(
                 f"Configuration '{path}' cannot be read because `pyyaml` is not installed. "
                 f"To fix, run `python -m pip install --upgrade pyyaml`.",
+                UserWarning,
             )
             return cls()
 

--- a/src/lakefs_spec/config.py
+++ b/src/lakefs_spec/config.py
@@ -15,12 +15,15 @@ class LakectlConfig(NamedTuple):
 
     @classmethod
     def read(cls, path: str | Path) -> "LakectlConfig":
+        if not Path(path).exists():
+            raise FileNotFoundError(path)
+
         try:
             import yaml
         except ModuleNotFoundError:
             logger.warning(
-                f"Configuration '{path}' exists, but cannot be read because the `pyyaml` package "
-                f"is not installed. To fix, run `python -m pip install --upgrade pyyaml`.",
+                f"Configuration '{path}' cannot be read because `pyyaml` is not installed. "
+                f"To fix, run `python -m pip install --upgrade pyyaml`.",
             )
             return cls()
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,7 @@ import sys
 from pathlib import Path
 
 import pytest
-from pytest import LogCaptureFixture, MonkeyPatch
+from pytest import MonkeyPatch
 
 from lakefs_spec.config import LakectlConfig
 
@@ -17,13 +17,10 @@ def test_config_read_nonexistent_file():
 
 
 def test_lakectl_config_parsing_without_yaml(
-    monkeypatch: MonkeyPatch, caplog: LogCaptureFixture, temporary_lakectl_config: str
+    monkeypatch: MonkeyPatch, temporary_lakectl_config: str
 ) -> None:
     # unset YAML module from sys.modules.
     monkeypatch.setitem(sys.modules, "yaml", None)
 
-    LakectlConfig.read(Path("~/.lakectl.yaml").expanduser())
-
-    # look for the log record, assert that it has the `pyyaml` install instruction.
-    assert len(caplog.records) > 0
-    assert "`python -m pip install --upgrade pyyaml`." in caplog.records[0].message
+    with pytest.warns(UserWarning, match="`pyyaml` is not installed"):
+        LakectlConfig.read(Path("~/.lakectl.yaml").expanduser())

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+
+import pytest
+from pytest import LogCaptureFixture, MonkeyPatch
+
+from lakefs_spec.config import LakectlConfig
+
+
+def test_config_read_nonexistent_file():
+    """
+    Tests that a FileNotFoundError is raised when a lakectl config is read from
+    a nonexistent file.
+    """
+    with pytest.raises(FileNotFoundError):
+        LakectlConfig.read("aaaaaaaaaaaaaaaa.yaml")
+
+
+def test_lakectl_config_parsing_without_yaml(
+    monkeypatch: MonkeyPatch, caplog: LogCaptureFixture, temporary_lakectl_config: str
+) -> None:
+    # unset YAML module from sys.modules.
+    monkeypatch.setitem(sys.modules, "yaml", None)
+
+    LakectlConfig.read(Path("~/.lakectl.yaml").expanduser())
+
+    # look for the log record, assert that it has the `pyyaml` install instruction.
+    assert len(caplog.records) > 0
+    assert "`python -m pip install --upgrade pyyaml`." in caplog.records[0].message

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -1,6 +1,3 @@
-import sys
-
-from _pytest.logging import LogCaptureFixture
 from pytest import MonkeyPatch
 
 from lakefs_spec import LakeFSFileSystem
@@ -65,17 +62,3 @@ def test_initialization(monkeypatch: MonkeyPatch, temporary_lakectl_config: str)
     assert config.host == "http://lakefs.hello/api/v1"
     assert config.username == "my-user"
     assert config.password == "my-password"
-
-
-def test_lakectl_config_parsing_without_yaml(
-    monkeypatch: MonkeyPatch, caplog: LogCaptureFixture, temporary_lakectl_config: str
-) -> None:
-    LakeFSFileSystem.clear_instance_cache()
-
-    # unset YAML module from sys.modules.
-    monkeypatch.setitem(sys.modules, "yaml", None)
-    LakeFSFileSystem()
-
-    # look for the log record, assert that it has the `pyyaml` install instruction.
-    assert len(caplog.records) > 0
-    assert "`python -m pip install --upgrade pyyaml`." in caplog.records[0].message


### PR DESCRIPTION
Based on the class responsibility model, the `LakectlConfig` class should not assume that existence of the input file has already been checked.

However, in the file system case, this is necessary to gracefully decay into an empty config in case the default config does not exist, or cannot be read.

Fixes #126.