### PR TITLE
Switch out black for ruff format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,12 +22,8 @@ repos:
      - id: mypy
        types_or: [ python, pyi ]
        args: ["--ignore-missing-imports", "--scripts-are-modules"]
-  - repo: https://github.com/psf/black
-    rev: 23.10.1
-    hooks:
-      - id: black
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.3
+    rev: v0.1.4
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix ]


### PR DESCRIPTION
While it is considered experimental, it appears extremely capable, much much faster than black, and 99.99% compliant with black. Also, none of the listed intended departures from black style seem to apply to us.

Source on known deviations: https://docs.astral.sh/ruff/formatter/black/