### PR TITLE
Add lakeFS transactions

### DIFF
--- a/src/lakefs_spec/client_helpers.py
+++ b/src/lakefs_spec/client_helpers.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import logging
 
+from lakefs_sdk import BranchCreation
 from lakefs_sdk.client import LakeFSClient
-from lakefs_sdk.exceptions import NotFoundException
+from lakefs_sdk.exceptions import ApiException, NotFoundException
 from lakefs_sdk.models import CommitCreation, RevertCreation, TagCreation
 
 logger = logging.getLogger(__name__)
@@ -31,6 +32,36 @@ def commit(
 def create_tag(client: LakeFSClient, repository: str, ref: str, tag: str) -> None:
     tag_creation = TagCreation(id=tag, ref=ref)
     client.tags_api.create_tag(repository=repository, tag_creation=tag_creation)
+
+
+def ensure_branch(client: LakeFSClient, repository: str, branch: str, source_branch: str) -> None:
+    """
+    Checks if a branch exists. If not, it is created.
+    This implementation depends on server-side error handling.
+
+    Parameters
+    ----------
+    client: LakeFSClient
+        The lakeFS client configured for (and authenticated with) the target instance.
+    repository: str
+        Repository name.
+    branch: str
+        Name of the branch.
+    source_branch: str
+        Name of the source branch the new branch is created from.
+
+    Returns
+    -------
+    None
+    """
+
+    try:
+        new_branch = BranchCreation(name=branch, source=source_branch)
+        # client.branches_api.create_branch throws ApiException when branch exists
+        client.branches_api.create_branch(repository=repository, branch_creation=new_branch)
+        logger.info(f"Created new branch {branch!r} from branch {source_branch!r}.")
+    except ApiException:
+        pass
 
 
 def get_tags(client: LakeFSClient, repository: str) -> dict:

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -635,16 +635,7 @@ class LakeFSFileSystem(AbstractFileSystem):
                 storage_options=storage_options,
             )
         else:
-            size = Path(lpath).stat().st_size
-            callback.set_size(size)
-
-            with self.wrapped_api_call():
-                self.client.objects_api.upload_object(
-                    repository=repository, branch=branch, path=resource, content=lpath, **kwargs
-                )
-
-            # this is stupid, but the best we can do without multipart uploads.
-            callback.relative_update(size)
+            super().put_file(lpath=lpath, rpath=rpath, callback=callback, **kwargs)
 
         run_put_file_hook()
 

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -73,6 +73,9 @@ class LakeFSTransaction(Transaction):
         Finish transaction: Unwind file+versioning op stack via
          1. Committing or discarding in case of a file, and
          2. Conducting versioning operations using the file system's client.
+
+         No operations happen and all files are discarded if `commit` is False,
+         which is the case e.g. if an exception happens in the context manager.
         """
         for f in self.files:
             if isinstance(f, AbstractBufferedFile):
@@ -83,7 +86,8 @@ class LakeFSTransaction(Transaction):
             else:
                 # member is a client helper, with everything but the client bound
                 # via `functools.partial`.
-                f(self.fs.client)
+                if commit:
+                    f(self.fs.client)
         self.files = []
         self.fs._intrans = False
 

--- a/src/lakefs_spec/util.py
+++ b/src/lakefs_spec/util.py
@@ -1,9 +1,20 @@
+import hashlib
 import re
 
 from lakefs_sdk import __version__ as __lakefs_sdk_version__
 
 lakefs_sdk_version = tuple(int(v) for v in __lakefs_sdk_version__.split("."))
 del __lakefs_sdk_version__
+
+
+def md5_checksum(lpath: str, blocksize: int = 2**22) -> str:
+    with open(lpath, "rb") as f:
+        file_hash = hashlib.md5(usedforsecurity=False)
+        chunk = f.read(blocksize)
+        while chunk:
+            file_hash.update(chunk)
+            chunk = f.read(blocksize)
+    return file_hash.hexdigest()
 
 
 def parse(path: str) -> tuple[str, str, str]:

--- a/tests/test_lakefs_file.py
+++ b/tests/test_lakefs_file.py
@@ -1,5 +1,6 @@
 import pytest
 
+import lakefs_spec.spec
 from lakefs_spec import LakeFSFileSystem
 from tests.util import RandomFileFactory
 
@@ -37,9 +38,11 @@ def test_lakefs_file_open_write(
 
     rpath = f"{repository}/{temp_branch}/{random_file.name}"
 
+    lakefs_spec.spec._warn_on_fileupload = True
+
     with pytest.warns(
         UserWarning,
-        match=r"Calling `LakeFSFile\.open\(\)` in write mode results in unbuffered file uploads.*",
+        match=r"Calling `LakeFSFileSystem\.open\(\)` in write mode results in unbuffered file uploads.*",
     ):
         # try opening the remote file and writing to it
         with fs.open(rpath, "wb") as fp:

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from lakefs_spec import LakeFSFileSystem
 from tests.util import RandomFileFactory
 
@@ -23,5 +25,78 @@ def test_transaction_commit(
         repository=repository,
         ref=temp_branch,
     )
-    latest_commit = commits.results[0]  # commit log is ordered branch-tip-first
+    latest_commit = commits.results[0]
     assert latest_commit.message == message
+
+
+def test_transaction_tag(fs: LakeFSFileSystem, repository: str) -> None:
+    try:
+        # tag gets created on exit of the context.
+        with fs.transaction as tx:
+            tag = tx.tag(repository=repository, ref="main", tag="v2")
+
+        assert any(commit.id == tag for commit in fs.client.tags_api.list_tags(repository).results)
+    finally:
+        fs.client.tags_api.delete_tag(repository=repository, tag=tag)
+
+
+def test_transaction_merge(
+    random_file_factory: RandomFileFactory,
+    fs: LakeFSFileSystem,
+    repository: str,
+    temp_branch: str,
+    temporary_branch_context: Any,
+) -> None:
+    random_file = random_file_factory.make()
+
+    with temporary_branch_context("transaction-merge-test") as new_branch:
+        resource = f"{repository}/{new_branch}/{random_file.name}"
+        message = "Commit new file"
+
+        with fs.transaction as tx:
+            # stage a file on new_branch...
+            fs.put(str(random_file), resource)
+            # ... commit it with the above message
+            tx.commit(
+                repository=repository,
+                branch=new_branch,
+                message=message,
+            )
+            # ... and merge it into temp_branch.
+            tx.merge(repository=repository, source_ref=new_branch, into=temp_branch)
+
+        # at last, verify temp_branch@HEAD is the merge commit.
+        commits = fs.client.refs_api.log_commits(
+            repository=repository,
+            ref=temp_branch,
+        )
+        latest_commit = commits.results[0]
+        assert latest_commit.message == f"Merge {new_branch!r} into {temp_branch!r}"
+        second_latest_commit = commits.results[1]
+        assert second_latest_commit.message == message
+
+
+def test_transaction_revert(
+    random_file_factory: RandomFileFactory,
+    fs: LakeFSFileSystem,
+    repository: str,
+    temp_branch: str,
+) -> None:
+    random_file = random_file_factory.make()
+
+    lpath = str(random_file)
+    rpath = f"{repository}/{temp_branch}/{random_file.name}"
+
+    message = f"Add file {random_file.name}"
+
+    with fs.transaction as tx:
+        fs.put_file(lpath, rpath)
+        tx.commit(repository, temp_branch, message=message)
+        tx.revert(repository=repository, branch=temp_branch)
+
+    commits = fs.client.refs_api.log_commits(
+        repository=repository,
+        ref=temp_branch,
+    )
+    latest_commit = commits.results[0]
+    assert latest_commit.message == f"Revert {temp_branch}"

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -100,3 +100,30 @@ def test_transaction_revert(
     )
     latest_commit = commits.results[0]
     assert latest_commit.message == f"Revert {temp_branch}"
+
+
+def test_transaction_branch(fs: LakeFSFileSystem, repository: str) -> None:
+    branch = "new-hello"
+
+    try:
+        with fs.transaction as tx:
+            tx.create_branch(repository=repository, branch=branch, source_branch="main")
+
+        branches = [
+            b.id for b in fs.client.branches_api.list_branches(repository=repository).results
+        ]
+
+        # existence check for a newly created branch.
+        assert branch in branches
+
+    finally:
+        fs.client.branches_api.delete_branch(
+            repository=repository,
+            branch=branch,
+        )
+
+
+def test_transaction_entry(fs: LakeFSFileSystem) -> None:
+    fs.start_transaction()
+    assert fs._intrans
+    assert fs._transaction is not None

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -1,0 +1,27 @@
+from lakefs_spec import LakeFSFileSystem
+from tests.util import RandomFileFactory
+
+
+def test_transaction_commit(
+    random_file_factory: RandomFileFactory,
+    fs: LakeFSFileSystem,
+    repository: str,
+    temp_branch: str,
+) -> None:
+    random_file = random_file_factory.make()
+
+    lpath = str(random_file)
+    rpath = f"{repository}/{temp_branch}/{random_file.name}"
+
+    message = f"Add file {random_file.name}"
+
+    with fs.transaction as tx:
+        fs.put_file(lpath, rpath)
+        tx.commit(repository, temp_branch, message=message)
+
+    commits = fs.client.refs_api.log_commits(
+        repository=repository,
+        ref=temp_branch,
+    )
+    latest_commit = commits.results[0]  # commit log is ordered branch-tip-first
+    assert latest_commit.message == message


### PR DESCRIPTION
Introduces a subclass of fsspec's builtin transactions called `LakeFSTransaction`, which in addition to its normal use has a number of predefined common versioning operations.

As the transaction is supposed to be used within the context manager block, the generator signature was changed to return the transaction instance, which is a departure from the fsspec instance.

When versioning operations are requested, they are forwarded to their respective client helper function along with their supplied arguments, and the stack of file objects and versioning ops is unwound in the context manager's exit method.