### PR TITLE
Add ruff-format hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,7 @@ repos:
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix ]
+      - id: ruff-format
   - repo: https://github.com/PyCQA/bandit
     rev: 1.7.5
     hooks:

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -508,9 +508,7 @@ class LakeFSFileSystem(AbstractFileSystem):
                         raise ValueError("Wrong protocol for remote connection")
                     else:
                         logger.info(f"Begin upload of {lpath}")
-                        with urllib.request.urlopen(
-                            request
-                        ):  # nosec [B310:blacklist] # We catch faulty protocols above.
+                        with urllib.request.urlopen(request):  # nosec [B310:blacklist] # We catch faulty protocols above.
                             logger.info(f"Successfully uploaded {lpath}")
                 except urllib.error.HTTPError as e:
                     urllib_http_error_as_lakefs_api_exception = ApiException(


### PR DESCRIPTION
Otherwise, we do not have any automated formatting in CI anymore after the black removal.

Also fixes a format difference, inlining a larger comment.