### PR TITLE
Improve lakeFS transactions by using deque, placeholders for commit SHAs

### DIFF
--- a/src/lakefs_spec/__init__.py
+++ b/src/lakefs_spec/__init__.py
@@ -2,7 +2,8 @@
 
 from importlib.metadata import PackageNotFoundError, version
 
-from .spec import LakeFSFile, LakeFSFileSystem, LakeFSTransaction
+from .spec import LakeFSFile, LakeFSFileSystem
+from .transaction import LakeFSTransaction
 
 try:
     __version__ = version("lakefs-spec")

--- a/src/lakefs_spec/client_helpers.py
+++ b/src/lakefs_spec/client_helpers.py
@@ -5,7 +5,7 @@ import logging
 from lakefs_sdk import BranchCreation
 from lakefs_sdk.client import LakeFSClient
 from lakefs_sdk.exceptions import ApiException, NotFoundException
-from lakefs_sdk.models import CommitCreation, RevertCreation, TagCreation
+from lakefs_sdk.models import Commit, CommitCreation, RevertCreation, TagCreation
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -17,27 +17,31 @@ def commit(
     branch: str,
     message: str,
     metadata: dict[str, str] | None = None,
-) -> None:
+) -> Commit:
     diff = client.branches_api.diff_branch(repository=repository, branch=branch)
 
     if not diff.results:
         logger.warning(f"No changes to commit on branch {branch!r}, aborting commit.")
-        return
+        return rev_parse(client, repository, branch, parent=0)
 
     commit_creation = CommitCreation(message=message, metadata=metadata or {})
 
-    client.commits_api.commit(repository=repository, branch=branch, commit_creation=commit_creation)
+    new_commit = client.commits_api.commit(
+        repository=repository, branch=branch, commit_creation=commit_creation
+    )
+    return new_commit
 
 
-def create_tag(client: LakeFSClient, repository: str, ref: str, tag: str) -> None:
+def create_tag(client: LakeFSClient, repository: str, ref: str | Commit, tag: str) -> None:
+    if isinstance(ref, Commit):
+        ref = ref.id
     tag_creation = TagCreation(id=tag, ref=ref)
     client.tags_api.create_tag(repository=repository, tag_creation=tag_creation)
 
 
-def ensure_branch(client: LakeFSClient, repository: str, branch: str, source_branch: str) -> None:
+def ensure_branch(client: LakeFSClient, repository: str, branch: str, source_branch: str) -> str:
     """
-    Checks if a branch exists. If not, it is created.
-    This implementation depends on server-side error handling.
+    Creates a branch named ``branch`` if not already existent.
 
     Parameters
     ----------
@@ -52,7 +56,7 @@ def ensure_branch(client: LakeFSClient, repository: str, branch: str, source_bra
 
     Returns
     -------
-    None
+    The branch name that was given.
     """
 
     try:
@@ -62,6 +66,8 @@ def ensure_branch(client: LakeFSClient, repository: str, branch: str, source_bra
         logger.info(f"Created new branch {branch!r} from branch {source_branch!r}.")
     except ApiException:
         pass
+
+    return branch
 
 
 def get_tags(client: LakeFSClient, repository: str) -> dict:
@@ -103,21 +109,22 @@ def revert(client: LakeFSClient, repository: str, branch: str, parent_number: in
 def rev_parse(
     client: LakeFSClient,
     repository: str,
-    ref: str,
+    ref: str | Commit,
     parent: int = 0,
-) -> str:
+) -> Commit:
     if parent < 0:
         raise ValueError(f"Parent cannot be negative, got {parent}")
     try:
+        if isinstance(ref, Commit):
+            ref = ref.id
         revisions = client.refs_api.log_commits(
             repository=repository, ref=ref, limit=True, amount=2 * (parent + 1)
         ).results
         if len(revisions) <= parent:
             raise ValueError(
-                f"cannot fetch revision {ref}~{parent}: {ref} only has {len(revisions)} parents"
+                f"cannot fetch revision {ref}~{parent}: "
+                f"ref {ref!r} only has {len(revisions)} parents"
             )
-        return revisions[parent].id
+        return revisions[parent]
     except NotFoundException:
-        raise RuntimeError(
-            f"{ref!r} does not match any revision in lakeFS repository {repository!r}"
-        )
+        raise ValueError(f"{ref!r} does not match any revision in lakeFS repository {repository!r}")

--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -8,23 +8,22 @@ import os
 import urllib.error
 import urllib.request
 from contextlib import contextmanager
-from functools import partial
 from pathlib import Path
-from typing import Any, Callable, Generator, Literal, overload
+from typing import Any, Generator, Literal, overload
 
 from fsspec import filesystem
 from fsspec.callbacks import Callback, NoOpCallback
 from fsspec.spec import AbstractBufferedFile, AbstractFileSystem
-from fsspec.transaction import Transaction
 from fsspec.utils import stringify_path
 from lakefs_sdk import Configuration
 from lakefs_sdk.client import LakeFSClient
 from lakefs_sdk.exceptions import ApiException, NotFoundException
 from lakefs_sdk.models import ObjectCopyCreation, ObjectStatsList, StagingMetadata
 
-from lakefs_spec.client_helpers import commit, create_tag, ensure_branch, merge, revert
+from lakefs_spec.client_helpers import ensure_branch
 from lakefs_spec.config import LakectlConfig
 from lakefs_spec.errors import translate_lakefs_error
+from lakefs_spec.transaction import LakeFSTransaction
 from lakefs_spec.util import md5_checksum, parse
 
 _DEFAULT_CALLBACK = NoOpCallback()
@@ -32,82 +31,6 @@ _DEFAULT_CALLBACK = NoOpCallback()
 logger = logging.getLogger(__name__)
 
 EmptyYield = Generator[None, None, None]
-
-
-class LakeFSTransaction(Transaction):
-    """A lakeFS transaction model capable of versioning operations in between file uploads."""
-
-    def __init__(self, fs: LakeFSFileSystem):
-        """
-        Initialize a lakeFS transaction. The base class' `file` stack can also contain
-        versioning operations.
-        """
-        super().__init__(fs=fs)
-        self.fs: LakeFSFileSystem
-        self.files: list[AbstractBufferedFile | Callable[[LakeFSClient], None]]
-
-    def __enter__(self):
-        self.start()
-        return self
-
-    def commit(
-        self, repository: str, branch: str, message: str, metadata: dict[str, str] | None = None
-    ) -> None:
-        """
-        Create a commit on a branch in a repository with a commit message and attached metadata.
-        """
-
-        # bind all arguments to the client helper function, and then add it to the file-/callstack.
-        op = partial(
-            commit, repository=repository, branch=branch, message=message, metadata=metadata
-        )
-        self.files.append(op)
-
-    def complete(self, commit: bool = True) -> None:
-        """
-        Finish transaction: Unwind file+versioning op stack via
-         1. Committing or discarding in case of a file, and
-         2. Conducting versioning operations using the file system's client.
-
-         No operations happen and all files are discarded if `commit` is False,
-         which is the case e.g. if an exception happens in the context manager.
-        """
-        for f in self.files:
-            if isinstance(f, AbstractBufferedFile):
-                if commit:
-                    f.commit()
-                else:
-                    f.discard()
-            else:
-                # member is a client helper, with everything but the client bound
-                # via `functools.partial`.
-                if commit:
-                    f(self.fs.client)
-        self.files = []
-        self.fs._intrans = False
-
-    def create_branch(self, repository: str, branch: str, source_branch: str) -> str:
-        op = partial(
-            ensure_branch, repository=repository, branch=branch, source_branch=source_branch
-        )
-        self.files.append(op)
-        return branch
-
-    def merge(self, repository: str, source_ref: str, into: str) -> None:
-        """Merge a branch into another branch in a repository."""
-        op = partial(merge, repository=repository, source_ref=source_ref, target_branch=into)
-        self.files.append(op)
-
-    def revert(self, repository: str, branch: str, parent_number: int = 1) -> None:
-        """Revert a previous commit on a branch."""
-        op = partial(revert, repository=repository, branch=branch, parent_number=parent_number)
-        self.files.append(op)
-
-    def tag(self, repository: str, ref: str, tag: str) -> str:
-        """Create a tag referencing a commit in a repository."""
-        op = partial(create_tag, repository=repository, ref=ref, tag=tag)
-        self.files.append(op)
-        return tag
 
 
 class LakeFSFileSystem(AbstractFileSystem):
@@ -290,8 +213,7 @@ class LakeFSFileSystem(AbstractFileSystem):
         if orig_repo != dest_repo:
             raise ValueError(
                 "can only copy objects within a repository, but got source "
-                f"repository {orig_repo!r} and destination repository "
-                f"{dest_repo!r}"
+                f"repository {orig_repo!r} and destination repository {dest_repo!r}"
             )
 
         with self.wrapped_api_call():

--- a/src/lakefs_spec/transaction.py
+++ b/src/lakefs_spec/transaction.py
@@ -1,0 +1,148 @@
+from collections import deque
+from dataclasses import dataclass
+from functools import partial
+from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar
+
+from fsspec.spec import AbstractBufferedFile
+from fsspec.transaction import Transaction
+from lakefs_sdk.client import LakeFSClient
+from lakefs_sdk.models import Commit
+
+from lakefs_spec.client_helpers import commit, create_tag, ensure_branch, merge, rev_parse, revert
+
+T = TypeVar("T")
+
+if TYPE_CHECKING:
+    from lakefs_spec import LakeFSFileSystem
+
+    VersioningOpTuple = tuple[Callable[[LakeFSFileSystem], None], Any]
+else:
+    VersioningOpTuple = tuple[Callable[["LakeFSFileSystem"], None], Any]
+
+
+@dataclass
+class Placeholder(Generic[T]):
+    value: T | None = None
+
+    def available(self):
+        return self.value is not None
+
+    def set_value(self, value: T) -> None:
+        self.value = value
+
+    def unwrap(self) -> T:
+        if self.value is None:
+            raise RuntimeError("placeholder unfilled")
+        return self.value
+
+
+def unwrap_placeholders(kwargs: dict[str, Any]) -> dict[str, Any]:
+    return {k: v.unwrap() if isinstance(v, Placeholder) else v for k, v in kwargs.items()}
+
+
+class LakeFSTransaction(Transaction):
+    """A lakeFS transaction model capable of versioning operations in between file uploads."""
+
+    def __init__(self, fs: "LakeFSFileSystem"):
+        """
+        Initialize a lakeFS transaction. The base class' `file` stack can also contain
+        versioning operations.
+        """
+        super().__init__(fs=fs)
+        self.fs: "LakeFSFileSystem"
+        self.files: deque[AbstractBufferedFile | VersioningOpTuple] = deque(self.files)
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def commit(
+        self, repository: str, branch: str, message: str, metadata: dict[str, str] | None = None
+    ) -> Placeholder[Commit]:
+        """
+        Create a commit on a branch in a repository with a commit message and attached metadata.
+        """
+
+        # bind all arguments to the client helper function, and then add it to the file-/callstack.
+        op = partial(
+            commit, repository=repository, branch=branch, message=message, metadata=metadata
+        )
+        p: Placeholder[Commit] = Placeholder()
+        self.files.append((op, p))
+        # return a placeholder for the commit.
+        return p
+
+    def complete(self, commit: bool = True) -> None:
+        """
+        Finish transaction: Unwind file+versioning op stack via
+         1. Committing or discarding in case of a file, and
+         2. Conducting versioning operations using the file system's client.
+
+         No operations happen and all files are discarded if `commit` is False,
+         which is the case e.g. if an exception happens in the context manager.
+        """
+        while self.files:
+            # fsspec base class calls `append` on the file, which means we
+            # have to pop from the left to preserve order.
+            f = self.files.popleft()
+            if isinstance(f, AbstractBufferedFile):
+                if commit:
+                    f.commit()
+                else:
+                    f.discard()
+            else:
+                # client helper + return value case.
+                op, retval = f
+                if commit:
+                    result = op(self.fs.client)
+                    # if the transaction member returns a placeholder,
+                    # fill it with the result of the client helper.
+                    if isinstance(retval, Placeholder):
+                        retval.set_value(result)
+
+        self.fs._intrans = False
+
+    def create_branch(self, repository: str, branch: str, source_branch: str) -> str:
+        op = partial(
+            ensure_branch, repository=repository, branch=branch, source_branch=source_branch
+        )
+        self.files.append((op, branch))
+        return branch
+
+    def merge(self, repository: str, source_ref: str, into: str) -> None:
+        """Merge a branch into another branch in a repository."""
+        op = partial(merge, repository=repository, source_ref=source_ref, target_branch=into)
+        self.files.append((op, None))
+        return None
+
+    def revert(self, repository: str, branch: str, parent_number: int = 1) -> None:
+        """Revert a previous commit on a branch."""
+        op = partial(revert, repository=repository, branch=branch, parent_number=parent_number)
+        self.files.append((op, None))
+        return None
+
+    def rev_parse(
+        self, repository: str, ref: str | Placeholder[str], parent: int = 0
+    ) -> Placeholder[Commit]:
+        def rev_parse_op(client: LakeFSClient, **kwargs: Any) -> Commit:
+            kwargs = unwrap_placeholders(kwargs)
+            return rev_parse(client, **kwargs)
+
+        p: Placeholder[Commit] = Placeholder()
+        op = partial(rev_parse_op, repository=repository, ref=ref, parent=parent)
+        self.files.append((op, p))
+        return p
+
+    def start(self):
+        """Start a transaction on the LakeFSFileSystem."""
+        self.fs._intrans = True
+
+    def tag(self, repository: str, ref: str | Placeholder[Commit], tag: str) -> str:
+        """Create a tag referencing a commit in a repository."""
+
+        def tag_op(client: LakeFSClient, **kwargs: str) -> None:
+            kwargs = unwrap_placeholders(kwargs)
+            return create_tag(client, **kwargs)
+
+        self.files.append((partial(tag_op, repository=repository, ref=ref, tag=tag), tag))
+        return tag

--- a/src/lakefs_spec/transaction.py
+++ b/src/lakefs_spec/transaction.py
@@ -103,6 +103,9 @@ class LakeFSTransaction(Transaction):
         self.fs._intrans = False
 
     def create_branch(self, repository: str, branch: str, source_branch: str) -> str:
+        """
+        Create a branch with the name `branch` in a repository, branching off `source_branch`.
+        """
         op = partial(
             ensure_branch, repository=repository, branch=branch, source_branch=source_branch
         )
@@ -124,6 +127,8 @@ class LakeFSTransaction(Transaction):
     def rev_parse(
         self, repository: str, ref: str | Placeholder[Commit], parent: int = 0
     ) -> Placeholder[Commit]:
+        """Parse a given reference or any of its parents in a repository."""
+
         def rev_parse_op(client: LakeFSClient, **kwargs: Any) -> Commit:
             kwargs = unwrap_placeholders(kwargs)
             return rev_parse(client, **kwargs)

--- a/tests/test_client_helpers.py
+++ b/tests/test_client_helpers.py
@@ -113,18 +113,18 @@ def test_revert(
 def test_rev_parse(
     fs: LakeFSFileSystem, random_file_factory: RandomFileFactory, repository: str, temp_branch: str
 ) -> None:
-    current_head_commit = (
-        fs.client.refs_api.log_commits(repository=repository, ref=temp_branch).results[0].id
-    )
+    current_head_commit = fs.client.refs_api.log_commits(
+        repository=repository, ref=temp_branch
+    ).results[0]
     random_file = random_file_factory.make()
     fs.put(str(random_file), f"{repository}/{temp_branch}/{random_file.name}")
     client_helpers.commit(
         client=fs.client, repository=repository, branch=temp_branch, message="New Commit"
     )
 
-    next_head_commit = (
-        fs.client.refs_api.log_commits(repository=repository, ref=temp_branch).results[0].id
-    )
+    next_head_commit = fs.client.refs_api.log_commits(
+        repository=repository, ref=temp_branch
+    ).results[0]
 
     assert (
         client_helpers.rev_parse(client=fs.client, repository=repository, ref=temp_branch, parent=0)
@@ -139,8 +139,8 @@ def test_rev_parse(
 def test_rev_parse_error_on_commit_not_found(fs: LakeFSFileSystem, repository: str) -> None:
     non_existent_ref = f"{uuid.uuid4()}"
     with pytest.raises(
-        RuntimeError,
-        match=f"{non_existent_ref!r} does not match any revision in lakeFS repository {repository!r}",
+        ValueError,
+        match=f"{non_existent_ref!r} does not match any revision",
     ):
         client_helpers.rev_parse(
             client=fs.client, repository=repository, ref=non_existent_ref, parent=0
@@ -154,7 +154,7 @@ def test_rev_parse_error_on_parent_does_not_exist(
     non_existent_parent = n_commits + 1
     with pytest.raises(
         ValueError,
-        match=f"cannot fetch revision {temp_branch}~{non_existent_parent}: {temp_branch} only has {n_commits} parents",
+        match=f"cannot fetch revision {temp_branch}~{non_existent_parent}",
     ):
         client_helpers.rev_parse(
             client=fs.client, repository=repository, ref=temp_branch, parent=non_existent_parent

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -165,5 +165,5 @@ def test_transaction_failure(
     except RuntimeError:
         pass
 
-    # assert that no second commit was attempted because of the exception.
+    # assert that no commit happens because of the exception.
     assert counter.count("commits_api.commit") == 0


### PR DESCRIPTION
Similarly to `fsspec`, the transaction now lives in the `lakefs_spec.transaction` submodule.

Introduces the `Placeholder` generic type for a deferred value that is only available after transaction completion.

This is important for values that are not available immediately after execution of a transaction helper, such as a commit SHA, which has to be computed first by the backend, and this happens only on transaction completion.

To be able to still pass these values to other consumers in the transaction, the `ref` argument was changed to also take a `Placeholder` as an argument.

The placeholder is tracked by the transaction's file+op queue, and populated with the actual return value of the executed underlying client helper after the client helper operation completes.

In subsequent operations consuming these placeholder values (with now populated values), the placeholder values are unpacked before the client helper execution, which keeps the client helper interface clean.

These details are hidden away from the user, who just proceeds to use commit SHAs as normal. However, printing these placeholders during the transaction will not show the value for obvious reasons.

----------------------

**Improve client helpers module by allowing commit objects as inputs**

Since the commit object returned by the lakeFS backend contains useful information, we return them from the `commit` and `rev_parse` helpers instead of just their SHA values.

This means that some interfaces have to be relaxed to allow commits, such as the `create_tag` interface (specifically, its `ref` argument).

The tests were adjusted to reflect this new behavior.