### PR TITLE
Make `pyyaml` dependency mandatory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 
-dependencies = ["fsspec>=2023.6.0", "lakefs-sdk>=1.0.0"]
+dependencies = ["fsspec>=2023.6.0", "lakefs-sdk>=1.0.0","pyyaml>=6.0.1"]
 
 dynamic = ["version"]
 
@@ -47,7 +47,6 @@ dev = [
     "pytest>=7.4.0",
     "build>=0.10.0",
     "pytest-cov>=4.1.0",
-    "pyyaml>=6.0.1",
     "setuptools-scm[toml]>=7.1",
 ]
 docs = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ fsspec==2023.10.0
 lakefs-sdk==1.0.0
 pydantic==1.10.13
 python-dateutil==2.8.2
+pyyaml==6.0.1
 six==1.16.0
 typing-extensions==4.8.0
 urllib3==2.0.7

--- a/src/lakefs_spec/config.py
+++ b/src/lakefs_spec/config.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-import warnings
 from pathlib import Path
 from typing import Any, NamedTuple
+
+import yaml
 
 
 class LakectlConfig(NamedTuple):
@@ -14,16 +15,6 @@ class LakectlConfig(NamedTuple):
     def read(cls, path: str | Path) -> "LakectlConfig":
         if not Path(path).exists():
             raise FileNotFoundError(path)
-
-        try:
-            import yaml
-        except ModuleNotFoundError:
-            warnings.warn(
-                f"Configuration '{path}' cannot be read because `pyyaml` is not installed. "
-                f"To fix, run `python -m pip install --upgrade pyyaml`.",
-                UserWarning,
-            )
-            return cls()
 
         with open(path, "r") as f:
             obj: dict[str, Any] = yaml.safe_load(f)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,8 +1,4 @@
-import sys
-from pathlib import Path
-
 import pytest
-from pytest import MonkeyPatch
 
 from lakefs_spec.config import LakectlConfig
 
@@ -14,13 +10,3 @@ def test_config_read_nonexistent_file():
     """
     with pytest.raises(FileNotFoundError):
         LakectlConfig.read("aaaaaaaaaaaaaaaa.yaml")
-
-
-def test_lakectl_config_parsing_without_yaml(
-    monkeypatch: MonkeyPatch, temporary_lakectl_config: str
-) -> None:
-    # unset YAML module from sys.modules.
-    monkeypatch.setitem(sys.modules, "yaml", None)
-
-    with pytest.warns(UserWarning, match="`pyyaml` is not installed"):
-        LakectlConfig.read(Path("~/.lakectl.yaml").expanduser())


### PR DESCRIPTION
Since the PyYAML dependency is now mandatory, the check for it being installed is no longer necessary (as is the corresponding test).

Note: not updating the docs here, since this will happen in #129 and #142.

Closes issue #141