### PR TITLE
Remove file upload performance warning

### DIFF
--- a/src/lakefs_spec/spec.py
+++ b/src/lakefs_spec/spec.py
@@ -7,7 +7,6 @@ import operator
 import os
 import urllib.error
 import urllib.request
-import warnings
 from contextlib import contextmanager
 from functools import partial
 from pathlib import Path
@@ -31,11 +30,8 @@ from lakefs_spec.util import md5_checksum, parse
 _DEFAULT_CALLBACK = NoOpCallback()
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 EmptyYield = Generator[None, None, None]
-
-_warn_on_fileupload = True
 
 
 class LakeFSTransaction(Transaction):
@@ -430,17 +426,6 @@ class LakeFSFileSystem(AbstractFileSystem):
     ) -> LakeFSFile:
         if mode not in {"rb", "wb"}:
             raise NotImplementedError(f"unsupported mode {mode!r}")
-
-        if mode == "wb":
-            global _warn_on_fileupload
-            if _warn_on_fileupload:
-                warnings.warn(
-                    f"Calling `{self.__class__.__name__}.open()` in write mode results in unbuffered "
-                    "file uploads, because the lakeFS Python client does not support multipart "
-                    "uploads. Uploading large files unbuffered can have performance implications.",
-                    UserWarning,
-                )
-                _warn_on_fileupload = False
 
         return LakeFSFile(
             self,

--- a/tests/test_lakefs_file.py
+++ b/tests/test_lakefs_file.py
@@ -1,6 +1,5 @@
 import pytest
 
-import lakefs_spec.spec
 from lakefs_spec import LakeFSFileSystem
 from tests.util import RandomFileFactory
 
@@ -38,15 +37,9 @@ def test_lakefs_file_open_write(
 
     rpath = f"{repository}/{temp_branch}/{random_file.name}"
 
-    lakefs_spec.spec._warn_on_fileupload = True
-
-    with pytest.warns(
-        UserWarning,
-        match=r"Calling `LakeFSFileSystem\.open\(\)` in write mode results in unbuffered file uploads.*",
-    ):
-        # try opening the remote file and writing to it
-        with fs.open(rpath, "wb") as fp:
-            fp.write(orig_text)
+    # try opening the remote file and writing to it
+    with fs.open(rpath, "wb") as fp:
+        fp.write(orig_text)
 
     # pulling the written file down again, using ONLY built-in open (!)
     lpath = random_file.with_name(random_file.name + "_copy")


### PR DESCRIPTION
This warning is intrusive and we have direct blockstore uploads available for users, so it can be removed. A note in the docs will be added in a follow-up.