### PR TITLE
Reword Python environment installation guide

### DIFF
--- a/.github/actions/python-deps/action.yaml
+++ b/.github/actions/python-deps/action.yaml
@@ -22,7 +22,3 @@ runs:
         pip install -r requirements.txt -r requirements-dev.txt -r requirements-docs.txt
         pip install -e . --no-deps
       shell: bash
-    - name: Install demo dependencies
-      run: | 
-        pip install pandas scikit-learn 
-      shell: bash

--- a/docs/mkdocs_customization/extra.css
+++ b/docs/mkdocs_customization/extra.css
@@ -2,3 +2,12 @@
 code>.err:first-of-type {
     display: none;
 }
+
+table {
+    display: block;
+    max-width: -moz-fit-content;
+    max-width: fit-content;
+    margin: 0 auto;
+    overflow-x: auto;
+    white-space: nowrap;
+}

--- a/docs/tutorials/demo_data_science_project.ipynb
+++ b/docs/tutorials/demo_data_science_project.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "67fa0d7b",
+   "id": "d93f1762-0aef-4527-808b-0d9344e09bb4",
    "metadata": {
     "cell_marker": "\"\"\""
    },
@@ -12,6 +12,7 @@
     "In this notebook, we will complete a small end-to-end data science tutorial that employs `lakeFS-spec` for data versioning. We will use weather data to train a random forest classifier to predict whether a given day from now is a raining day given the current weather.\n",
     "\n",
     "We will do the following:\n",
+    "\n",
     "* Environment setup\n",
     "* lakeFS setup\n",
     "* Data ingestion\n",
@@ -24,32 +25,33 @@
     "\n",
     "To execute the code in this tutorial as a Jupyter notebook, download this `.ipynb` file to a convenient location on your machine. You can also clone the whole `lakefs-spec` repository. During the execution of this tutorial, in the same directory, a folder 'data' will be created. We will also download a file `.lakectl.yaml` to the current user's home directory.\n",
     "\n",
-    "Prerequisites before we start:\n",
-    "* Python 3.9 or higher\n",
-    "* Docker Desktop installed - [see guidance](https://www.docker.com/get-started/)\n",
-    "* git installed\n",
+    "This tutorial assumes that you have installed `lakefs-spec` in a virtual environment, and that you have followed the [quickstart guide](../quickstart.md) to set up a local lakeFS instance.\n",
     "\n",
     "# Environment Setup\n",
-    "To set up the environment, run the following commands in your console:\n",
     "\n",
-    "Create a virtual environment:\n",
-    "\n",
-    "`python -m venv .venv`\n",
-    "\n",
-    "Activate the environment.\n",
-    "\n",
-    "On macOS and Linux:\n",
-    "\n",
-    "`source .venv/bin/activate`\n",
-    "\n",
-    "On Windows:\n",
-    "\n",
-    "`.venv\\Scripts\\activate`\n",
-    "\n",
-    "Install the libraries necessary for this notebook on the environment you have just created: \n",
-    "\n",
-    "`pip install notebook lakefs-spec numpy pandas scikit-learn`.\n",
-    "\n",
+    "Install the libraries necessary for this notebook on the environment you have just created: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2a1b38a3-dd43-424e-be1a-9c731bdcf4f5",
+   "metadata": {
+    "cell_marker": "\"\"\"",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "! pip install notebook lakefs-spec numpy pandas scikit-learn"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd35daf1-e3a4-4b5b-91c9-5f365b8e13fe",
+   "metadata": {
+    "cell_marker": "\"\"\""
+   },
+   "source": [
     "From a terminal, start a Jupyter notebook server if one is not already running, by executing `jupyter notebook`. Double click the notebook to autostart a kernel using the created virtual environment.\n",
     "\n",
     "# lakeFS Setup\n",
@@ -145,9 +147,9 @@
    "id": "1d37daf2",
    "metadata": {},
    "source": [
-    "Now it's time to get some data. We will use the [Open Meteo api](https://open-meteo.com/), where we can pull weather data from an API for free (as long as we are non-commercial) and without an API-token.\n",
+    "Now it's time to get some data. We will use the [Open Meteo API](https://open-meteo.com/), where we can pull weather data from an API for free (as long as we are non-commercial) and without an API-token.\n",
     "\n",
-    "First, create the folder 'data' inside a directory when your notebook is located:"
+    "First, create the folder `data` inside a directory when your notebook is located:"
    ]
   },
   {
@@ -168,7 +170,7 @@
     "lines_to_next_cell": 0
    },
    "source": [
-    "Then, for the purpose of training, get the full data of the 2010s from Munich:"
+    "Then, for the purpose of training, get the full 2010 weather data from Munich:"
    ]
   },
   {
@@ -180,8 +182,8 @@
    },
    "outputs": [],
    "source": [
-    "destination = \"data/weather-2010s.json\"\n",
-    "urllib.request.urlretrieve(\"https://archive-api.open-meteo.com/v1/archive?latitude=52.52&longitude=13.41&start_date=2010-01-01&end_date=2019-12-31&hourly=temperature_2m,relativehumidity_2m,rain,pressure_msl,surface_pressure,cloudcover,cloudcover_low,cloudcover_mid,cloudcover_high,windspeed_10m,windspeed_100m,winddirection_10m,winddirection_100m\", destination)"
+    "destination = \"data/weather-2010.json\"\n",
+    "urllib.request.urlretrieve(\"https://archive-api.open-meteo.com/v1/archive?latitude=52.52&longitude=13.41&start_date=2010-01-01&end_date=2010-12-31&hourly=temperature_2m,relativehumidity_2m,rain,pressure_msl,surface_pressure,cloudcover,cloudcover_low,cloudcover_mid,cloudcover_high,windspeed_10m,windspeed_100m,winddirection_10m,winddirection_100m\", destination)"
    ]
   },
   {
@@ -215,7 +217,7 @@
     "NEW_BRANCH_NAME = 'transform-raw-data'\n",
     "\n",
     "fs = LakeFSFileSystem()\n",
-    "fs.put('./data/weather-2010s.json', f'{REPO_NAME}/{NEW_BRANCH_NAME}/weather-2010.json')"
+    "fs.put(destination, f'{REPO_NAME}/{NEW_BRANCH_NAME}/weather-2010.json')"
    ]
   },
   {
@@ -255,8 +257,8 @@
    "outputs": [],
    "source": [
     "with fs.transaction as tx:\n",
-    "    fs.put('data/weather-2010s.json', f'{REPO_NAME}/{NEW_BRANCH_NAME}/weather-2010.json', precheck=True, autocommit=False)\n",
-    "    tx.commit(repository=REPO_NAME, branch=NEW_BRANCH_NAME, message=\"Add weather data\")"
+    "    fs.put(destination, f'{REPO_NAME}/{NEW_BRANCH_NAME}/weather-2010.json', precheck=True, autocommit=False)\n",
+    "    tx.commit(repository=REPO_NAME, branch=NEW_BRANCH_NAME, message=\"Add 2010 weather data\")"
    ]
   },
   {
@@ -309,7 +311,7 @@
     "    df = df.dropna()\n",
     "    return df\n",
     "    \n",
-    "df = transform_json_weather_data('data/weather-2010s.json')\n",
+    "df = transform_json_weather_data('data/weather-2010.json')\n",
     "df.head(5)"
    ]
   },
@@ -331,7 +333,7 @@
    "outputs": [],
    "source": [
     "with fs.transaction as tx:\n",
-    "    df.to_csv(f'lakefs://{REPO_NAME}/main/weather_2010s.csv')\n",
+    "    df.to_csv(f'lakefs://{REPO_NAME}/main/weather_2010.csv')\n",
     "    tx.commit(repository=REPO_NAME, branch=\"main\", message=\"Update weather data\")"
    ]
   },
@@ -382,7 +384,7 @@
     "with fs.transaction as tx:\n",
     "    train.to_csv(f'lakefs://{REPO_NAME}/{TRAINING_BRANCH}/train_weather.csv')\n",
     "    test.to_csv(f'lakefs://{REPO_NAME}/{TRAINING_BRANCH}/test_weather.csv')\n",
-    "    tx.commit(repository=REPO_NAME, branch=TRAINING_BRANCH, message=\"Add train-test split of 2010s weather data\")"
+    "    tx.commit(repository=REPO_NAME, branch=TRAINING_BRANCH, message=\"Add train-test split of 2010 weather data\")"
    ]
   },
   {
@@ -448,11 +450,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from sklearn.ensemble import RandomForestClassifier\n",
+    "from sklearn.tree import DecisionTreeClassifier\n",
     "\n",
     "dependent_variable = 'is_raining_in_1_day'\n",
     "\n",
-    "model = RandomForestClassifier(random_state=7)\n",
+    "model = DecisionTreeClassifier(random_state=7)\n",
     "x_train, y_train = train.drop(dependent_variable, axis=1), train[dependent_variable].astype(bool)\n",
     "x_test, y_test = test.drop(dependent_variable, axis=1), test[dependent_variable].astype(bool)\n",
     "\n",
@@ -471,7 +473,7 @@
    },
    "source": [
     "# Updating Data and Model\n",
-    "Until now, we only have used data from the 2010s. Let's download additional 2020s data, transform it, and save it to LakeFS."
+    "Until now, we only have used data from 2010. Let's download additional 2020 data, transform it, and save it to LakeFS."
    ]
   },
   {
@@ -483,14 +485,14 @@
    },
    "outputs": [],
    "source": [
-    "destination = \"data/weather-2020s.json\"\n",
-    "urllib.request.urlretrieve(\"https://archive-api.open-meteo.com/v1/archive?latitude=52.52&longitude=13.41&start_date=2020-01-01&end_date=2023-08-31&hourly=temperature_2m,relativehumidity_2m,rain,pressure_msl,surface_pressure,cloudcover,cloudcover_low,cloudcover_mid,cloudcover_high,windspeed_10m,windspeed_100m,winddirection_10m,winddirection_100m\", destination)\n",
+    "destination = \"data/weather-2020.json\"\n",
+    "urllib.request.urlretrieve(\"https://archive-api.open-meteo.com/v1/archive?latitude=52.52&longitude=13.41&start_date=2020-01-01&end_date=2020-12-31&hourly=temperature_2m,relativehumidity_2m,rain,pressure_msl,surface_pressure,cloudcover,cloudcover_low,cloudcover_mid,cloudcover_high,windspeed_10m,windspeed_100m,winddirection_10m,winddirection_100m\", destination)\n",
     "\n",
-    "new_data = transform_json_weather_data('data/weather-2020s.json')\n",
+    "new_data = transform_json_weather_data('data/weather-2020.json')\n",
     "\n",
     "with fs.transaction as tx:\n",
-    "    new_data.to_csv(f'lakefs://{REPO_NAME}/main/weather_2020s.csv')\n",
-    "    tx.commit(repository=REPO_NAME, branch=\"main\", message=\"Add 2020s weather data\")"
+    "    new_data.to_csv(f'lakefs://{REPO_NAME}/main/weather_2020.csv')\n",
+    "    tx.commit(repository=REPO_NAME, branch=\"main\", message=\"Add 2020 weather data\")"
    ]
   },
   {
@@ -530,7 +532,7 @@
     "with fs.transaction as tx:\n",
     "    train_df.to_csv(f'lakefs://{REPO_NAME}/{TRAINING_BRANCH}/train_weather.csv')\n",
     "    test_df.to_csv(f'lakefs://{REPO_NAME}/{TRAINING_BRANCH}/test_weather.csv')\n",
-    "    tx.commit(repository=REPO_NAME, branch=TRAINING_BRANCH, message=\"Add train-test split of full 2010-2020s data\")"
+    "    tx.commit(repository=REPO_NAME, branch=TRAINING_BRANCH, message=\"Add train-test split of 2010 and 2020 data\")"
    ]
   },
   {
@@ -595,9 +597,9 @@
    "source": [
     "# Accessing Data Version and Reproducing Experiment\n",
     "\n",
-    "Let's assume we need to go to our initial data and reproduce the first experiment (the model trained on the 2010s data with its initial accuracy). This might be tricky as we have overwritten initial train and test data on lakeFS.\n",
+    "Let's assume we need to go to our initial data and reproduce the first experiment (the model trained on the 2010 data with its initial accuracy). This might be tricky as we have overwritten initial train and test data on lakeFS.\n",
     "\n",
-    "To enable data versioning we should save the `ref` of the specific datasets. `ref` can be a branch we are pulling a file from LakeFS. `ref` can be also a commit id - then you can access different data versions within the same branch and not only the version from the latest commit. Therefore, we will use explicit versioning and get the actual commit SHA. We have multiple ways to do this. Manually, we could go into the lakeFS UI, select the training branch, and navigate to the \"Commits\" tab. There, we could see the second-latest commit, titled `Add train-test split of 2010s weather data`, and copy its ID.\n",
+    "To enable data versioning we should save the `ref` of the specific datasets. `ref` can be a branch we are pulling a file from LakeFS. `ref` can be also a commit id - then you can access different data versions within the same branch and not only the version from the latest commit. Therefore, we will use explicit versioning and get the actual commit SHA. We have multiple ways to do this. Manually, we could go into the lakeFS UI, select the training branch, and navigate to the \"Commits\" tab. There, we could see the second-latest commit, titled `Add train-test split of 2010 weather data`, and copy its ID.\n",
     "\n",
     "However, we want to automate as much as possible and therefore use a helper function. You find pre-written helper functions in the `lakefs_spec.client_helpers` module:"
    ]

--- a/docs/tutorials/demo_data_science_project.ipynb
+++ b/docs/tutorials/demo_data_science_project.ipynb
@@ -23,7 +23,7 @@
     "* Accessing data versions and Reproducing Experiments\n",
     "* Using a tag instead of a commit SHA for semantic versioning\n",
     "\n",
-    "To execute the code in this tutorial as a Jupyter notebook, download this `.ipynb` file to a convenient location on your machine. You can also clone the whole `lakefs-spec` repository. During the execution of this tutorial, in the same directory, a folder 'data' will be created. We will also download a file `.lakectl.yaml` to the current user's home directory.\n",
+    "To execute the code in this tutorial as a Jupyter notebook, download this `.ipynb` file to a convenient location on your machine. You can also clone the whole `lakefs-spec` repository. During the execution of this tutorial, in the same directory, a folder `data` will be created. We will also download a file `.lakectl.yaml` to the current user's home directory.\n",
     "\n",
     "This tutorial assumes that you have installed `lakefs-spec` in a virtual environment, and that you have followed the [quickstart guide](../quickstart.md) to set up a local lakeFS instance.\n",
     "\n",
@@ -38,11 +38,13 @@
    "id": "2a1b38a3-dd43-424e-be1a-9c731bdcf4f5",
    "metadata": {
     "cell_marker": "\"\"\"",
-    "tags": []
+    "tags": [
+     "remove_output"
+    ]
    },
    "outputs": [],
    "source": [
-    "! pip install notebook lakefs-spec numpy pandas scikit-learn"
+    "! pip install lakefs-spec numpy pandas scikit-learn"
    ]
   },
   {

--- a/docs/tutorials/demo_data_science_project.ipynb
+++ b/docs/tutorials/demo_data_science_project.ipynb
@@ -44,7 +44,7 @@
    },
    "outputs": [],
    "source": [
-    "! pip install lakefs-spec numpy pandas scikit-learn"
+    "%pip install lakefs-spec numpy pandas scikit-learn"
    ]
   },
   {

--- a/docs/tutorials/demo_data_science_project.ipynb
+++ b/docs/tutorials/demo_data_science_project.ipynb
@@ -26,7 +26,7 @@
     "\n",
     "Prerequisites before we start:\n",
     "* Python 3.9 or higher\n",
-    "* Docker desktop installed - [see guidance](https://www.docker.com/get-started/)\n",
+    "* Docker Desktop installed - [see guidance](https://www.docker.com/get-started/)\n",
     "* git installed\n",
     "\n",
     "# Environment Setup\n",
@@ -48,23 +48,21 @@
     "\n",
     "Install the libraries necessary for this notebook on the environment you have just created: \n",
     "\n",
-    "`pip install lakefs-spec numpy pandas scikit-learn`.\n",
+    "`pip install notebook lakefs-spec numpy pandas scikit-learn`.\n",
     "\n",
-    "From a terminal activate this Jupyter notebook (if not running already).\n",
-    "\n",
-    "In the notebook \"Kernel\" menu select the environment you just created as a Jupyter kernel.\n",
+    "From a terminal, start a Jupyter notebook server if one is not already running, by executing `jupyter notebook`. Double click the notebook to autostart a kernel using the created virtual environment.\n",
     "\n",
     "# lakeFS Setup\n",
     "\n",
-    "Ensure you have docker desktop is running.\n",
+    "Ensure you have Docker Desktop or a similar runtime available and running.\n",
     "\n",
-    "Set up LakeFS. You can do this by executing the `docker run` command given here (the lakeFS quickstart) in your console:\n",
+    "Set up LakeFS. You can do this by executing the following `docker run` command (the lakeFS quickstart) in your console:\n",
     "\n",
     "`docker run --name lakefs --pull always --rm --publish 8000:8000 treeverse/lakefs:latest run --quickstart`\n",
     "\n",
     "Open a browser and navigate to the lakeFS instance - by default: http://localhost:8000/. \n",
     "\n",
-    "Authenticate with the credentials provided https://docs.lakefs.io/quickstart/launch.html :\n",
+    "Authenticate with the following credentials:\n",
     "\n",
     "    Access Key ID    : AKIAIOSFOLQUICKSTART\n",
     "    Secret Access Key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\n",
@@ -73,7 +71,7 @@
     "\n",
     "Before we instantiate the filesystem connector `LakeFSFilesystem`, we need to configure authentication.\n",
     "\n",
-    "There many ways to authenticate to lakeFS while executing Python code - in this tutorial, we choose a convenient YAML file configuration. Execute the code below to download the YAML file including the lakeFS quickstart credentials and server URL. This file will be downloaded to your user directory."
+    "There are multiple ways to authenticate to lakeFS from Python code - in this tutorial, we choose the convenient YAML file configuration. Execute the code below to download the YAML file including the lakeFS quickstart credentials and server URL to your user directory."
    ]
   },
   {
@@ -131,8 +129,7 @@
    "source": [
     "from lakefs_spec.client_helpers import create_repository\n",
     "\n",
-    "create_repository(client=fs.client, name=REPO_NAME,\n",
-    "                  storage_namespace=f\"local://{REPO_NAME}\")"
+    "repo = create_repository(client=fs.client, name=REPO_NAME, storage_namespace=f\"local://{REPO_NAME}\")"
    ]
   },
   {
@@ -761,7 +758,7 @@
    }
   },
   "kernelspec": {
-   "display_name": ".demovenv",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -775,7 +772,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The previous iteration tried to give instructions for a hermetic virtual environment used via ipykernel, but never gave instructions on how to do so.

This change removes the recommendation to register the virtual environment as a hermetic kernel, and instead recommends to install all necessary dependencies into the single environment, including Jupyter Notebook itself.

Some minor style changes were made to the rest of the setup instructions, including capitalization of Docker everywhere and fixing some incorrect grammar.